### PR TITLE
CI: run reth-benchmark on self-hosted runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
   lints:
     name: Various lints
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, x64, linux, gpu]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,11 @@ jobs:
           targets: riscv32im-unknown-none-elf
           # TODO: figure out way to keep this in sync with rust-toolchain.toml automatically
           toolchain: nightly-2025-08-18
+      - name: Give Github Action access to ceno-gpu
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.SECRET_FOR_CENO_GPU }}
       - name: Cargo cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          components: rustfmt, clippy
+          components: rustfmt, clippy, rust-src
           targets: riscv32im-unknown-none-elf
           # TODO: figure out way to keep this in sync with rust-toolchain.toml automatically
           toolchain: nightly-2025-08-18

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           components: rustfmt, clippy, rust-src
           targets: riscv32im-unknown-none-elf
           # TODO: figure out way to keep this in sync with rust-toolchain.toml automatically
-          toolchain: nightly-2025-08-18
+          toolchain: nightly-2025-08-19
       - name: Give Github Action access to ceno-gpu
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           components: rustfmt, clippy, rust-src
           targets: riscv32im-unknown-none-elf
           # TODO: figure out way to keep this in sync with rust-toolchain.toml automatically
-          toolchain: nightly-2025-08-19
+          toolchain: nightly-2025-08-18
       - name: Give Github Action access to ceno-gpu
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,9 +70,12 @@ jobs:
           cargo fmt --all -- --check
 
   e2e:
-    name: "Run e2e test on block 23587691"
+    name: "Run e2e test on small block"
     runs-on: [self-hosted, x64, linux, gpu]
     timeout-minutes: 15
+    env:
+      BLOCK_NUM: 23587691
+      RPC_URL_1: ${{ secrets.RPC_URL_1 }}
     steps:
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,8 +96,8 @@ jobs:
           toolchain: nightly-2025-08-19
 
       - name: "Build cargo-ceno toolchain"
-        env: JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,metadata_thp:always,thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
         run: |
+          JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,metadata_thp:always,thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true" \
           cargo install --git https://github.com/scroll-tech/ceno.git --features jemalloc --features nightly-features cargo-ceno
 
       - name: "Build ELF"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,6 +82,9 @@ jobs:
       - name: "Checkout sources"
         uses: "actions/checkout@v4"
 
+      - name: "Install cmake"
+        run: sudo apt-get install -y cmake
+
       - name: "Setup Rust"
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,8 +97,6 @@ jobs:
 
       - name: "Build cargo-ceno toolchain"
         run: |
-          cargo --version
-          rustc --version
           JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,metadata_thp:always,thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true" \
           cargo install --git https://github.com/scroll-tech/ceno.git --features jemalloc --features nightly-features cargo-ceno
 
@@ -108,6 +106,7 @@ jobs:
 
       - name: "Run e2e test"
         run: |
+          mkdir -p output
           RUST_BACKTRACE=1 CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
           RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_*=warn \
           cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Update lock files"
         run: |
           cargo tree
-          (cd ./bin/client-eth && cargo tree)
+          (cd ./bin/ceno-client-eth && cargo tree)
 
       - name: "Assert no changes"
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           components: rust-src
           targets: riscv32im-unknown-none-elf
+          # TODO: figure out why cargo-ceno does not work with nightly-2025-08-19
           toolchain: nightly-2025-08-18
 
       - name: "Build cargo-ceno toolchain"
@@ -108,7 +109,7 @@ jobs:
         run: |
           mkdir -p output
           RUST_BACKTRACE=1 CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
-          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_*=warn \
+          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
           cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
             --bin ceno-reth-benchmark-bin --profile release -- --block-number $BLOCK_NUM \
             --rpc-url $RPC_URL_1 --cache-dir block_data --output-dir output --mode prove-stark

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   lock-files:
     name: "Check lock files"
-    runs-on: ["runs-on", "runner=8cpu-linux-x64", "run-id=${{ github.run_id }}"]
+    runs-on: [self-hosted, x64, linux, gpu]
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -22,7 +22,7 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
-            ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
+            ${{ secrets.SECRET_FOR_CENO_GPU }}
       - name: "Checkout sources"
         uses: "actions/checkout@v4"
 
@@ -40,13 +40,13 @@ jobs:
 
   fmt:
     name: "Check code format"
-    runs-on: ["runs-on", "runner=8cpu-linux-x64", "run-id=${{ github.run_id }}"]
+    runs-on: [self-hosted, x64, linux, gpu]
     steps:
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
-            ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
+            ${{ secrets.SECRET_FOR_CENO_GPU }}
       - name: "Checkout sources"
         uses: "actions/checkout@v4"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,6 +95,15 @@ jobs:
           targets: riscv32im-unknown-none-elf
           toolchain: nightly-2025-08-19
 
+      - name: "Build cargo-ceno toolchain"
+        env: JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,metadata_thp:always,thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
+        run: |
+          cargo install --git https://github.com/scroll-tech/ceno.git --features jemalloc --features nightly-features cargo-ceno
+
+      - name: "Build ELF"
+        run: |
+          cd bin/ceno-client-eth && cargo ceno build --release
+
       - name: "Run e2e test"
         run: |
           RUST_BACKTRACE=1 CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,13 @@ jobs:
       - name: "Checkout sources"
         uses: "actions/checkout@v4"
 
+      - name: "Setup nightly toolchain"
+        uses: "actions-rs/toolchain@v1"
+        with:
+          toolchain: nightly-2025-08-19
+          components: rustfmt, clippy
+          override: true
+
       - name: "Update lock files"
         run: |
           cargo tree
@@ -61,3 +68,31 @@ jobs:
       - name: "Check Rust format"
         run: |
           cargo fmt --all -- --check
+
+  e2e:
+    name: "Run e2e test on block 23587691"
+    runs-on: [self-hosted, x64, linux, gpu]
+    timeout-minutes: 15
+    steps:
+      - name: Load SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.SECRET_FOR_CENO_GPU }}
+      - name: "Checkout sources"
+        uses: "actions/checkout@v4"
+
+      - name: "Setup Rust"
+        uses: dtolnay/rust-toolchain@master
+        with:
+          components: rust-src
+          targets: riscv32im-unknown-none-elf
+          toolchain: nightly-2025-08-19
+
+      - name: "Run e2e test"
+        run: |
+          RUST_BACKTRACE=1 CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
+          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_*=warn \
+          cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
+            --bin ceno-reth-benchmark-bin --profile release -- --block-number $BLOCK_NUM \
+            --rpc-url $RPC_URL_1 --cache-dir block_data --output-dir output --mode prove-stark

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Setup nightly toolchain"
         uses: "actions-rs/toolchain@v1"
         with:
-          toolchain: nightly-2025-08-19
+          toolchain: nightly-2025-08-18
           components: rustfmt, clippy
           override: true
 
@@ -93,7 +93,7 @@ jobs:
         with:
           components: rust-src
           targets: riscv32im-unknown-none-elf
-          # TODO: figure out why cargo-ceno does not work with nightly-2025-08-19
+          # TODO: figure out why cargo-ceno does not work with nightly-2025-08-18
           toolchain: nightly-2025-08-18
 
       - name: "Build cargo-ceno toolchain"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           components: rust-src
           targets: riscv32im-unknown-none-elf
-          toolchain: nightly-2025-08-19
+          toolchain: nightly-2025-08-18
 
       - name: "Build cargo-ceno toolchain"
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,7 +89,7 @@ jobs:
         run: sudo apt-get install -y cmake
 
       - name: "Setup Rust"
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
           targets: riscv32im-unknown-none-elf
@@ -97,6 +97,8 @@ jobs:
 
       - name: "Build cargo-ceno toolchain"
         run: |
+          cargo --version
+          rustc --version
           JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,metadata_thp:always,thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true" \
           cargo install --git https://github.com/scroll-tech/ceno.git --features jemalloc --features nightly-features cargo-ceno
 

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -48,48 +48,39 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.SECRET_FOR_CENO_GPU }}
-
+      
       - name: Run benchmark locally
         run: |
           block_number="${{ inputs.block_number }}"
-#          s3_url="https://axiom-public-data-sandbox-us-east-1.s3.us-east-1.amazonaws.com/reth/input/${block_number}.json"
+          # Install Ceno CLI
+          echo "Installing Ceno CLI..."
+          cargo install --git https://github.com/scroll-tech/ceno.git  --locked --force cargo-ceno
 
-#          echo "Checking if input file exists for block $block_number..."
-#          if curl --output /dev/null --silent --head --fail "$s3_url"; then
-#            echo "Input file found in S3, downloading..."
-#            curl -o input.json "$s3_url"
-#          else
-#            echo "Input file not found in S3, generating locally..."
+          RPC_1=${{ secrets.RPC_URL_1 }}
 
-            # Install Ceno CLI
-            echo "Installing Ceno CLI..."
-            cargo install --git https://github.com/scroll-tech/ceno.git  --locked --force cargo-ceno
+          # Build client binary
+          cd bin/ceno-client-eth
+          cargo ceno build --release
 
-            RPC_1=${{ secrets.RPC_URL_1 }}
+          cd ../..
 
-            # Build client binary
-            cd bin/ceno-client-eth
-            cargo ceno build --release
+          # Create necessary directories
+          mkdir -p output
+          mkdir -p rpc-cache
 
-            cd ../..
+          # Build the benchmark binary
+          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
+          cargo build --bin ceno-reth-benchmark-bin --profile=release --no-default-features --features="jemalloc,gpu"
 
-            # Create necessary directories
-            mkdir -p output
-            mkdir -p rpc-cache
+          echo "Generating e2e proof for block $block_number..."
+          ./target/release/ceno-reth-benchmark-bin \
+            --mode prove-stark \
+            --block-number $block_number \
+            --rpc-url ${{ secrets.RPC_URL_1 }} \
+            --output-dir output \
+            --cache-dir rpc-cache
 
-            # Build the benchmark binary
-            export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
-            cargo build --bin ceno-reth-benchmark-bin --profile=release --no-default-features --features="jemalloc,gpu"
-
-            echo "Generating e2e proof for block $block_number..."
-            ./target/release/ceno-reth-benchmark-bin \
-              --mode prove-stark \
-              --block-number $block_number \
-              --rpc-url ${{ secrets.RPC_URL_1 }} \
-              --output-dir output \
-              --cache-dir rpc-cache
-
-            echo "e2e proof generated successfully"
+          echo "e2e proof generated successfully"
 #          fi
 #
 #          # Verify input file exists

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Generating e2e proof for block $block_number..."
           export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
           CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
-          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_*=warn \
+          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
           cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
             --release --bin ceno-reth-benchmark-bin -- \
             --mode prove-stark \

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           cache: false
 
+      - name: Give Github Action access to ceno-gpu
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.SECRET_FOR_CENO_GPU }}
+
       - name: Run benchmark locally
         run: |
           block_number="${{ inputs.block_number }}"

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -68,12 +68,12 @@ jobs:
           mkdir -p output
           mkdir -p rpc-cache
 
-          # Build the benchmark binary
-          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
-          cargo build --bin ceno-reth-benchmark-bin --profile=release --no-default-features --features="jemalloc,gpu"
-
           echo "Generating e2e proof for block $block_number..."
-          ./target/release/ceno-reth-benchmark-bin \
+          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
+          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
+          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_*=warn \
+          cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
+            --release --bin ceno-reth-benchmark-bin -- \
             --mode prove-stark \
             --block-number $block_number \
             --rpc-url ${{ secrets.RPC_URL_1 }} \

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -1,10 +1,10 @@
-name: "OpenVM Benchmark v2"
+name: "Ceno Benchmark v2"
 
 on:
   workflow_dispatch:
     inputs:
-      openvm_version:
-        description: "OpenVM version (commit sha) to benchmark"
+      ceno_version:
+        description: "Ceno version (commit sha) to benchmark"
         required: true
         type: string
       block_number:
@@ -33,7 +33,7 @@ on:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, x64, linux, gpu]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -55,40 +55,33 @@ jobs:
           else
             echo "Input file not found in S3, generating locally..."
 
-            # Install OpenVM CLI
-            echo "Installing OpenVM CLI..."
-            cargo +1.85 install --git https://github.com/openvm-org/openvm.git --locked --force cargo-openvm
+            # Install Ceno CLI
+            echo "Installing Ceno CLI..."
+            cargo install --git https://github.com/scroll-tech/ceno.git  --locked --force cargo-ceno
 
             RPC_1=${{ secrets.RPC_URL_1 }}
 
             # Build client binary
-            cd bin/client-eth
-            cargo openvm build
-            mkdir -p ../host/elf
-            SRC="target/riscv32im-risc0-zkvm-elf/release/openvm-client-eth"
-            DEST="../host/elf/openvm-client-eth"
+            cd bin/ceno-client-eth
+            cargo ceno build --release
 
-            if [ ! -f "$DEST" ] || ! cmp -s "$SRC" "$DEST"; then
-                cp "$SRC" "$DEST"
-            fi
             cd ../..
 
             # Create necessary directories
+            mkdir -p output
             mkdir -p rpc-cache
-            mkdir -p params
 
             # Build the benchmark binary
             export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
-            cargo build --bin openvm-reth-benchmark-bin --profile=release --no-default-features --features="bench-metrics,nightly-features,jemalloc,evm-verify"
+            cargo build --bin ceno-reth-benchmark-bin --profile=release --no-default-features --features="jemalloc,gpu"
 
             # Generate input data
             echo "Generating input for block $block_number..."
             ./target/release/openvm-reth-benchmark-bin \
-              --kzg-params-dir params \
-              --mode make-input \
+              --mode prove-stark \
               --block-number $block_number \
               --rpc-url ${{ secrets.RPC_URL_1 }} \
-              --input-path input.json \
+              --output-dir output \
               --cache-dir rpc-cache
 
             echo "Input file generated successfully"
@@ -102,204 +95,205 @@ jobs:
 
           echo "Input file ready: $(ls -lh input.json)"
 
-      - name: Prepare benchmark
-        id: prepare
-        run: |
-          # Build JSON payload using jq for proper JSON construction
-          json_payload=$(jq -n \
-            --arg openvm_commit "${{ inputs.openvm_version }}" \
-            '{openvm_commit: $openvm_commit}')
-
-          if [ "${{ inputs.rerun_keygen }}" = "true" ]; then
-            json_payload=$(echo "$json_payload" | jq '. + {rekeygen: true}')
-          fi
-
-          if [ "${{ inputs.recompile_reth }}" = "true" ]; then
-            json_payload=$(echo "$json_payload" | jq '. + {recompile: true}')
-          fi
-
-          echo "Final JSON payload: $json_payload"
-
-          response=$(curl -X POST \
-            -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d "$json_payload" \
-            https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs)
-          echo "Response: $response"
-          benchmark_id=$(echo "$response" | jq -r '.id')
-          echo "benchmark_id=$benchmark_id" >> $GITHUB_OUTPUT
-
-      - name: Wait for benchmark preparation
-        run: |
-          benchmark_id="${{ steps.prepare.outputs.benchmark_id }}"
-          echo "Waiting for benchmark $benchmark_id to be ready..."
-
-          max_iterations=80 # 40min
-          iteration=0
-
-          while [ $iteration -lt $max_iterations ]; do
-            response=$(curl -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
-              https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs/$benchmark_id)
-            echo "Response: $response"
-
-            status=$(echo "$response" | jq -r '.status')
-            echo "Status: $status (iteration $((iteration + 1))/$max_iterations)"
-
-            if [ "$status" = "ready" ]; then
-              echo "Benchmark is ready!"
-              break
-            fi
-
-            if [ "$status" = "failed" ]; then
-              echo "Benchmark failed!"
-              exit 1
-            fi
-
-            iteration=$((iteration + 1))
-
-            if [ $iteration -lt $max_iterations ]; then
-              echo "Waiting 30 seconds before next check..."
-              sleep 30
-            fi
-          done
-
-          if [ $iteration -eq $max_iterations ]; then
-            echo "Timeout: Benchmark preparation did not complete within 10 minutes (20 iterations)"
-            exit 1
-          fi
-
-      - name: prove
-        id: prove
-        run: |
-          benchmark_id="${{ steps.prepare.outputs.benchmark_id }}"
-          echo "Getting program_uuid for benchmark $benchmark_id..."
-
-          sleep 180  # wait 3 min to make sure the prove service is ready
-
-          response=$(curl -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
-            https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs/$benchmark_id)
-          echo "Response: $response"
-
-          program_uuid=$(echo "$response" | jq -r '.program_uuid')
-          echo "Program UUID: $program_uuid"
-
-          echo "Submitting proof with JSON data..."
-          response=$(curl -X POST \
-            -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d @input.json \
-            "https://api.staging.app.axiom.xyz/v1/proofs?program_id=$program_uuid")
-          echo "Response: $response"
-          proof_id=$(echo "$response" | jq -r '.id')
-          echo "proof_id=$proof_id" >> $GITHUB_OUTPUT
-
-      - name: Wait for proof
-        run: |
-          proof_id="${{ steps.prove.outputs.proof_id }}"
-          echo "Waiting for proof $proof_id to complete..."
-
-          max_iterations=20 # 10min
-          iteration=0
-
-          while [ $iteration -lt $max_iterations ]; do
-            response=$(curl -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
-              https://api.staging.app.axiom.xyz/v1/proofs/$proof_id)
-            echo "Response: $response"
-
-            status=$(echo "$response" | jq -r '.state')
-            echo "Status: $status (iteration $((iteration + 1))/$max_iterations)"
-
-            if [ "$status" = "Succeeded" ] || [ "$status" = "Failed" ]; then
-              echo "Proof completed with status: $status"
-              break
-            fi
-
-            iteration=$((iteration + 1))
-
-            if [ $iteration -lt $max_iterations ]; then
-              echo "Waiting 30 seconds before next check..."
-              sleep 30
-            fi
-          done
-
-          if [ $iteration -eq $max_iterations ]; then
-            echo "Timeout: Proof did not complete within 10 minutes (20 iterations)"
-            echo "WORKFLOW_FAILED=true" >> $GITHUB_ENV
-          fi
-
-      - name: Cleanup
-        if: ${{ inputs.cleanup == true }}
-        run: |
-          benchmark_id="${{ steps.prepare.outputs.benchmark_id }}"
-          echo "Deleting benchmark $benchmark_id..."
-          response=$(curl -X DELETE \
-            -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
-            "https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs/$benchmark_id")
-          echo "Response: $response"
-
-      - name: Download and display metrics
-        run: |
-          if [ "$WORKFLOW_FAILED" = "true" ]; then
-            echo "skipping metrics download"
-          else
-            proof_id="${{ steps.prove.outputs.proof_id }}"
-            echo "Downloading metrics for proof $proof_id..."
-
-            max_iterations=10 # 5 minutes total
-            iteration=0
-
-            while [ $iteration -lt $max_iterations ]; do
-              echo "Attempting to download metrics (attempt $((iteration + 1))/$max_iterations)..."
-
-              response_code=$(curl -w "%{http_code}" -s -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
-                "https://api.staging.app.axiom.xyz/v1/internal/benchmark_metrics/$proof_id" \
-                -o metrics.md)
-
-              echo "HTTP response code: $response_code"
-
-              if [ "$response_code" = "200" ]; then
-                echo "Metrics downloaded successfully!"
-                break
-              elif [ "$response_code" = "404" ]; then
-                echo "Metrics not ready yet (404), waiting 30 seconds before retry..."
-                rm -f metrics.md  # Clean up partial file
-                iteration=$((iteration + 1))
-
-                if [ $iteration -lt $max_iterations ]; then
-                  sleep 30
-                fi
-              else
-                echo "Unexpected response code: $response_code"
-                rm -f metrics.md  # Clean up partial file
-                echo "METRICS_FAILED=true" >> $GITHUB_ENV
-                break
-              fi
-            done
-
-            if [ $iteration -eq $max_iterations ]; then
-              echo "Timeout: Metrics were not available after 5 minutes"
-              echo "METRICS_FAILED=true" >> $GITHUB_ENV
-            elif [ "$response_code" = "200" ]; then
-              echo "Metrics downloaded to metrics.md"
-              echo "=== BENCHMARK METRICS ==="
-              cat metrics.md
-              echo "========================="
-            fi
-          fi
-
-      - name: Upload metrics as artifact
-        if: env.WORKFLOW_FAILED != 'true' && env.METRICS_FAILED != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-metrics-${{ inputs.openvm_version }}
-          path: metrics.md
-          retention-days: 30
-
-      - name: Check workflow status
-        run: |
-          if [ "$WORKFLOW_FAILED" = "true" ]; then
-            echo "Workflow failed due to timeout or proof failure"
-            exit 1
-          else
-            echo "Workflow completed successfully"
-          fi
+#      - name: Prepare benchmark
+#        id: prepare
+#        run: |
+#          # Build JSON payload using jq for proper JSON construction
+#          json_payload=$(jq -n \
+#            --arg openvm_commit "${{ inputs.openvm_version }}" \
+#            '{openvm_commit: $openvm_commit}')
+#
+#          if [ "${{ inputs.rerun_keygen }}" = "true" ]; then
+#            json_payload=$(echo "$json_payload" | jq '. + {rekeygen: true}')
+#          fi
+#
+#          if [ "${{ inputs.recompile_reth }}" = "true" ]; then
+#            json_payload=$(echo "$json_payload" | jq '. + {recompile: true}')
+#          fi
+#
+#          echo "Final JSON payload: $json_payload"
+#
+#          response=$(curl -X POST \
+#            -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
+#            -H "Content-Type: application/json" \
+#            -d "$json_payload" \
+#            https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs)
+#          echo "Response: $response"
+#          benchmark_id=$(echo "$response" | jq -r '.id')
+#          echo "benchmark_id=$benchmark_id" >> $GITHUB_OUTPUT
+#
+#      - name: Wait for benchmark preparation
+#        run: |
+#          benchmark_id="${{ steps.prepare.outputs.benchmark_id }}"
+#          echo "Waiting for benchmark $benchmark_id to be ready..."
+#
+#          max_iterations=80 # 40min
+#          iteration=0
+#
+#          while [ $iteration -lt $max_iterations ]; do
+#            response=$(curl -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
+#              https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs/$benchmark_id)
+#            echo "Response: $response"
+#
+#            status=$(echo "$response" | jq -r '.status')
+#            echo "Status: $status (iteration $((iteration + 1))/$max_iterations)"
+#
+#            if [ "$status" = "ready" ]; then
+#              echo "Benchmark is ready!"
+#              break
+#            fi
+#
+#            if [ "$status" = "failed" ]; then
+#              echo "Benchmark failed!"
+#              exit 1
+#            fi
+#
+#            iteration=$((iteration + 1))
+#
+#            if [ $iteration -lt $max_iterations ]; then
+#              echo "Waiting 30 seconds before next check..."
+#              sleep 30
+#            fi
+#          done
+#
+#          if [ $iteration -eq $max_iterations ]; then
+#            echo "Timeout: Benchmark preparation did not complete within 10 minutes (20 iterations)"
+#            exit 1
+#          fi
+#
+#      - name: prove
+#        id: prove
+#        run: |
+#          benchmark_id="${{ steps.prepare.outputs.benchmark_id }}"
+#          echo "Getting program_uuid for benchmark $benchmark_id..."
+#
+#          sleep 180  # wait 3 min to make sure the prove service is ready
+#
+#          response=$(curl -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
+#            https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs/$benchmark_id)
+#          echo "Response: $response"
+#
+#          program_uuid=$(echo "$response" | jq -r '.program_uuid')
+#          echo "Program UUID: $program_uuid"
+#
+#          echo "Submitting proof with JSON data..."
+#          response=$(curl -X POST \
+#            -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
+#            -H "Content-Type: application/json" \
+#            -d @input.json \
+#            "https://api.staging.app.axiom.xyz/v1/proofs?program_id=$program_uuid")
+#          echo "Response: $response"
+#          proof_id=$(echo "$response" | jq -r '.id')
+#          echo "proof_id=$proof_id" >> $GITHUB_OUTPUT
+#
+#      - name: Wait for proof
+#        run: |
+#          proof_id="${{ steps.prove.outputs.proof_id }}"
+#          echo "Waiting for proof $proof_id to complete..."
+#
+#          max_iterations=20 # 10min
+#          iteration=0
+#
+#          while [ $iteration -lt $max_iterations ]; do
+#            response=$(curl -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
+#              https://api.staging.app.axiom.xyz/v1/proofs/$proof_id)
+#            echo "Response: $response"
+#
+#            status=$(echo "$response" | jq -r '.state')
+#            echo "Status: $status (iteration $((iteration + 1))/$max_iterations)"
+#
+#            if [ "$status" = "Succeeded" ] || [ "$status" = "Failed" ]; then
+#              echo "Proof completed with status: $status"
+#              break
+#            fi
+#
+#            iteration=$((iteration + 1))
+#
+#            if [ $iteration -lt $max_iterations ]; then
+#              echo "Waiting 30 seconds before next check..."
+#              sleep 30
+#            fi
+#          done
+#
+#          if [ $iteration -eq $max_iterations ]; then
+#            echo "Timeout: Proof did not complete within 10 minutes (20 iterations)"
+#            echo "WORKFLOW_FAILED=true" >> $GITHUB_ENV
+#          fi
+#
+#      - name: Cleanup
+#        if: ${{ inputs.cleanup == true }}
+#        run: |
+#          benchmark_id="${{ steps.prepare.outputs.benchmark_id }}"
+#          echo "Deleting benchmark $benchmark_id..."
+#          response=$(curl -X DELETE \
+#            -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
+#            "https://api.staging.app.axiom.xyz/v1/internal/benchmark_jobs/$benchmark_id")
+#          echo "Response: $response"
+#
+#      - name: Download and display metrics
+#        run: |
+#          if [ "$WORKFLOW_FAILED" = "true" ]; then
+#            echo "skipping metrics download"
+#          else
+#            proof_id="${{ steps.prove.outputs.proof_id }}"
+#            echo "Downloading metrics for proof $proof_id..."
+#
+#            max_iterations=10 # 5 minutes total
+#            iteration=0
+#
+#            while [ $iteration -lt $max_iterations ]; do
+#              echo "Attempting to download metrics (attempt $((iteration + 1))/$max_iterations)..."
+#
+#              response_code=$(curl -w "%{http_code}" -s -H "Axiom-API-Key: ${{ secrets.PROVING_SERVICE_API_KEY }}" \
+#                "https://api.staging.app.axiom.xyz/v1/internal/benchmark_metrics/$proof_id" \
+#                -o metrics.md)
+#
+#              echo "HTTP response code: $response_code"
+#
+#              if [ "$response_code" = "200" ]; then
+#                echo "Metrics downloaded successfully!"
+#                break
+#              elif [ "$response_code" = "404" ]; then
+#                echo "Metrics not ready yet (404), waiting 30 seconds before retry..."
+#                rm -f metrics.md  # Clean up partial file
+#                iteration=$((iteration + 1))
+#
+#                if [ $iteration -lt $max_iterations ]; then
+#                  sleep 30
+#                fi
+#              else
+#                echo "Unexpected response code: $response_code"
+#                rm -f metrics.md  # Clean up partial file
+#                echo "METRICS_FAILED=true" >> $GITHUB_ENV
+#                break
+#              fi
+#            done
+#
+#            if [ $iteration -eq $max_iterations ]; then
+#              echo "Timeout: Metrics were not available after 5 minutes"
+#              echo "METRICS_FAILED=true" >> $GITHUB_ENV
+#            elif [ "$response_code" = "200" ]; then
+#              echo "Metrics downloaded to metrics.md"
+#              echo "=== BENCHMARK METRICS ==="
+#              cat metrics.md
+#              echo "========================="
+#            fi
+#          fi
+#
+#      - name: Upload metrics as artifact
+#        if: env.WORKFLOW_FAILED != 'true' && env.METRICS_FAILED != 'true'
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: benchmark-metrics-${{ inputs.openvm_version }}
+#          path: metrics.md
+#          retention-days: 30
+#
+#      - name: Check workflow status
+#        run: |
+#          if [ "$WORKFLOW_FAILED" = "true" ]; then
+#            echo "Workflow failed due to timeout or proof failure"
+#            exit 1
+#          else
+#            echo "Workflow completed successfully"
+#          fi
+#

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -76,7 +76,7 @@ jobs:
             cargo build --bin ceno-reth-benchmark-bin --profile=release --no-default-features --features="jemalloc,gpu"
 
             echo "Generating e2e proof for block $block_number..."
-            ./target/release/openvm-reth-benchmark-bin \
+            ./target/release/ceno-reth-benchmark-bin \
               --mode prove-stark \
               --block-number $block_number \
               --rpc-url ${{ secrets.RPC_URL_1 }} \

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -43,17 +43,17 @@ jobs:
         with:
           cache: false
 
-      - name: Prepare input data
+      - name: Run benchmark locally
         run: |
           block_number="${{ inputs.block_number }}"
-          s3_url="https://axiom-public-data-sandbox-us-east-1.s3.us-east-1.amazonaws.com/reth/input/${block_number}.json"
+#          s3_url="https://axiom-public-data-sandbox-us-east-1.s3.us-east-1.amazonaws.com/reth/input/${block_number}.json"
 
-          echo "Checking if input file exists for block $block_number..."
-          if curl --output /dev/null --silent --head --fail "$s3_url"; then
-            echo "Input file found in S3, downloading..."
-            curl -o input.json "$s3_url"
-          else
-            echo "Input file not found in S3, generating locally..."
+#          echo "Checking if input file exists for block $block_number..."
+#          if curl --output /dev/null --silent --head --fail "$s3_url"; then
+#            echo "Input file found in S3, downloading..."
+#            curl -o input.json "$s3_url"
+#          else
+#            echo "Input file not found in S3, generating locally..."
 
             # Install Ceno CLI
             echo "Installing Ceno CLI..."
@@ -75,8 +75,7 @@ jobs:
             export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
             cargo build --bin ceno-reth-benchmark-bin --profile=release --no-default-features --features="jemalloc,gpu"
 
-            # Generate input data
-            echo "Generating input for block $block_number..."
+            echo "Generating e2e proof for block $block_number..."
             ./target/release/openvm-reth-benchmark-bin \
               --mode prove-stark \
               --block-number $block_number \
@@ -84,17 +83,17 @@ jobs:
               --output-dir output \
               --cache-dir rpc-cache
 
-            echo "Input file generated successfully"
-          fi
-
-          # Verify input file exists
-          if [ ! -f "input.json" ]; then
-            echo "Error: input.json file not found!"
-            exit 1
-          fi
-
-          echo "Input file ready: $(ls -lh input.json)"
-
+            echo "e2e proof generated successfully"
+#          fi
+#
+#          # Verify input file exists
+#          if [ ! -f "input.json" ]; then
+#            echo "Error: input.json file not found!"
+#            exit 1
+#          fi
+#
+#          echo "Input file ready: $(ls -lh input.json)"
+#
 #      - name: Prepare benchmark
 #        id: prepare
 #        run: |

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,30 @@
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
+
+ARG RUNNER_VERSION="2.320.0"
+# replace this with the actual token which you can get from GitHub
+ARG TOKEN=""
+# replace this with the actual server name you want to use
+ARG SERVER_NAME="scroll-SEA2-10"
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -y && apt upgrade -y && useradd -m docker
+RUN apt install -y --no-install-recommends \
+    curl jq build-essential libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip \
+    libkrb5-3 zlib1g libicu70 m4
+
+RUN cd /home/docker && mkdir actions-runner && cd actions-runner \
+    && curl -o actions-runner-linux-x64-2.320.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.320.0/actions-runner-linux-x64-2.320.0.tar.gz \
+    && echo "93ac1b7ce743ee85b5d386f5c1787385ef07b3d7c728ff66ce0d3813d5f46900  actions-runner-linux-x64-2.320.0.tar.gz" | shasum -a 256 -c \
+    && tar xzf ./actions-runner-linux-x64-2.320.0.tar.gz
+
+RUN chown -R docker ~docker && cd /home/docker/actions-runner/bin/ \
+    && chmod +x installdependencies.sh \
+    && ./installdependencies.sh
+
+RUN apt install -y nvidia-utils-535
+RUN apt install -y openssh-client
+
+RUN apt install -y --no-install-recommends sudo && \
+    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+RUN RUNNER_ALLOW_RUNASROOT=1 /home/docker/actions-runner/config.sh --unattended --url https://github.com/scroll-tech/ceno-reth-benchmark --token $TOKEN --name $SERVER_NAME --labels gpu

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,11 @@
+## Summary
+
+Before building the docker image, we need to fetch the token from GitHub [page](https://github.com/scroll-tech/ceno-reth-benchmark/settings/actions/runners/new?arch=x64&os=linux). The docker image for running our own self-hosted runner can be built from
+```shell
+docker build -t ceno-reth-gpu:v1 .
+```
+
+And then we can spin up the docker image via
+```shell
+docker run --gpus device=0 -it ceno-reth-gpu:v1 /bin/bash
+```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 #channel = "1.86.0"
 # To use the "tco" feature, switch to Rust nightly:
-channel = "nightly-2025-08-19"
+channel = "nightly-2025-08-18"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
Having the following tasks running on self-hosted server that has `1x 4090` which has same configuration as the server for ethproofs.

- [x] lint.yml
- [x] pr.yml
- [x] run-benchmark-v2.yml