### PR TITLE
more robust ci and move secret data to runtime

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
 
 ARG RUNNER_VERSION="2.320.0"
@@ -20,6 +22,14 @@ RUN chown -R docker ~docker && cd /home/docker/actions-runner/bin/ \
 RUN apt install -y nvidia-utils-535
 RUN apt install -y openssh-client
 RUN apt install -y git
+
+# Validate SSH access for private dependencies (requires --ssh sshkey=... at build time)
+RUN --mount=type=ssh,id=sshkey \
+    set -eux; \
+    mkdir -p /root/.ssh; \
+    chmod 700 /root/.ssh; \
+    ssh-keyscan github.com >> /root/.ssh/known_hosts; \
+    git ls-remote git@github.com:scroll-tech/ceno-reth-benchmark.git >/dev/null
 
 RUN apt install -y --no-install-recommends sudo && \
     echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,10 +1,6 @@
 FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
 
 ARG RUNNER_VERSION="2.320.0"
-# replace this with the actual token which you can get from GitHub
-ARG TOKEN=""
-# replace this with the actual server name you want to use
-ARG SERVER_NAME="scroll-SEA2-10"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && apt upgrade -y && useradd -m docker
@@ -23,8 +19,14 @@ RUN chown -R docker ~docker && cd /home/docker/actions-runner/bin/ \
 
 RUN apt install -y nvidia-utils-535
 RUN apt install -y openssh-client
+RUN apt install -y git
 
 RUN apt install -y --no-install-recommends sudo && \
     echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-RUN RUNNER_ALLOW_RUNASROOT=1 /home/docker/actions-runner/config.sh --unattended --url https://github.com/scroll-tech/ceno-reth-benchmark --token $TOKEN --name $SERVER_NAME --labels gpu
+WORKDIR /home/docker/actions-runner
+
+COPY ci/runner-entrypoint.sh /usr/local/bin/runner-entrypoint.sh
+RUN chmod +x /usr/local/bin/runner-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/runner-entrypoint.sh"]

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,11 +1,19 @@
 ## Summary
 
-Before building the docker image, we need to fetch the token from GitHub [page](https://github.com/scroll-tech/ceno-reth-benchmark/settings/actions/runners/new?arch=x64&os=linux). The docker image for running our own self-hosted runner can be built from
+Before building the docker image, fetch a fresh registration token from the GitHub [runner page](https://github.com/scroll-tech/ceno-reth-benchmark/settings/actions/runners/new?arch=x64&os=linux) and decide on a `SERVER_NAME` label for this runner.
+
+Build the image (no secrets are needed at build time):
 ```shell
 docker build -t ceno-reth-gpu:v1 .
 ```
 
-And then we can spin up the docker image via
+Spin up the docker image by supplying the token and runner name at runtime:
 ```shell
-docker run --gpus device=0 -it ceno-reth-gpu:v1 /bin/bash
+docker run --gpus device=0 --name ceno-reth-runner -d \
+  -e RUNNER_TOKEN="$TOKEN" \
+  -e RUNNER_NAME="$SERVER_NAME" \
+  -e RUNNER_URL="https://github.com/scroll-tech/ceno-reth-benchmark" \
+  ceno-reth-gpu:v1
 ```
+
+You may optionally set `RUNNER_LABELS` (defaults to `gpu`). The container’s entrypoint configures the runner via the provided token on startup and then launches `RUNNER_ALLOW_RUNASROOT=1 /home/docker/actions-runner/run.sh`, so no manual SSH is required.

--- a/ci/README.md
+++ b/ci/README.md
@@ -2,9 +2,12 @@
 
 Before building the docker image, fetch a fresh registration token from the GitHub [runner page](https://github.com/scroll-tech/ceno-reth-benchmark/settings/actions/runners/new?arch=x64&os=linux) and decide on a `SERVER_NAME` label for this runner.
 
-Build the image (no secrets are needed at build time):
+Build the image (enable BuildKit so we can forward an SSH key for private Git clones):
 ```shell
-docker build -t ceno-reth-gpu:v1 .
+DOCKER_BUILDKIT=1 docker build \
+  --ssh sshkey="$HOME/.ssh/id_ed25519" \
+  -t ceno-reth-gpu:v1 \
+  -f ci/Dockerfile .
 ```
 
 Spin up the docker image by supplying the token and runner name at runtime:

--- a/ci/runner-entrypoint.sh
+++ b/ci/runner-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNNER_DIR="/home/docker/actions-runner"
+RUNNER_URL="${RUNNER_URL:-https://github.com/scroll-tech/ceno-reth-benchmark}"
+RUNNER_NAME="${RUNNER_NAME:-}"
+RUNNER_TOKEN="${RUNNER_TOKEN:-}"
+RUNNER_LABELS="${RUNNER_LABELS:-gpu}"
+
+if [[ -z "$RUNNER_NAME" ]]; then
+  echo "[runner-entrypoint] RUNNER_NAME must be provided" >&2
+  exit 1
+fi
+
+if [[ -z "$RUNNER_TOKEN" ]]; then
+  echo "[runner-entrypoint] RUNNER_TOKEN must be provided" >&2
+  exit 1
+fi
+
+cleanup() {
+  if [[ -f "$RUNNER_DIR/.runner" ]]; then
+    echo "[runner-entrypoint] Removing runner registration" >&2
+    RUNNER_ALLOW_RUNASROOT=1 "$RUNNER_DIR/config.sh" remove --token "$RUNNER_TOKEN" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [[ ! -f "$RUNNER_DIR/.runner" ]]; then
+  echo "[runner-entrypoint] Configuring runner ${RUNNER_NAME} for ${RUNNER_URL}" >&2
+  RUNNER_ALLOW_RUNASROOT=1 "$RUNNER_DIR/config.sh" \
+    --unattended \
+    --url "$RUNNER_URL" \
+    --token "$RUNNER_TOKEN" \
+    --name "$RUNNER_NAME" \
+    --labels "$RUNNER_LABELS"
+fi
+
+cd "$RUNNER_DIR"
+echo "[runner-entrypoint] Starting GitHub Actions runner" >&2
+exec env RUNNER_ALLOW_RUNASROOT=1 ./run.sh


### PR DESCRIPTION
Current `ci/Dockerfile` requires manual attach into docker then execute ci registration command. This PR resolved the issue by moving to entrypoint so we can launch docker in daemon mode `-d` directly

 