### PR TITLE
ci: support dispatch benchmark refs and report results to source PR

### DIFF
--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -428,7 +428,6 @@ jobs:
   report-to-source-pr:
     if: ${{ always() && inputs.source_repository != '' && inputs.source_pr_number != '' }}
     needs:
-      - check-gpu-mem-estimation
       - benchmark
     runs-on: ubuntu-latest
     steps:
@@ -440,7 +439,6 @@ jobs:
           CENO_VERSION: ${{ inputs.ceno_version != '' && inputs.ceno_version || 'pinned Cargo.toml version' }}
           BENCHMARK_RESULT: ${{ needs.benchmark.result }}
           BENCHMARK_RESULT_URL: ${{ needs.benchmark.outputs.result_url }}
-          MEM_RESULT: ${{ needs.check-gpu-mem-estimation.result }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ secrets.CENO_PR_COMMENT_TOKEN }}
@@ -454,7 +452,6 @@ jobs:
               "",
               `- ceno version: \`${process.env.CENO_VERSION}\``,
               `- benchmark job: \`${benchmarkResult}\``,
-              `- gpu mem estimation job: \`${memResult}\``,
               `- workflow run: ${process.env.RUN_URL}`,
             ];
             if (process.env.BENCHMARK_RESULT_URL) {

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -8,6 +8,16 @@ on:
         required: false
         type: string
         default: ""
+      source_repository:
+        description: "Origin repository to comment back to"
+        required: false
+        type: string
+        default: ""
+      source_pr_number:
+        description: "Origin pull request number to comment back to"
+        required: false
+        type: string
+        default: ""
       block_number:
         description: "Block number to generate input for"
         required: true
@@ -204,6 +214,8 @@ jobs:
   benchmark:
     if: ${{ inputs.run_gpu_benchmark }}
     runs-on: [self-hosted, x64, linux, gpu]
+    outputs:
+      result_url: ${{ steps.result_link.outputs.url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -396,6 +408,11 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           cat "${{ env.GH_PAGES_PATH }}/${{ env.LOG_NAME }}_summary.md" >> $GITHUB_STEP_SUMMARY
 
+      - name: Record result link
+        id: result_link
+        run: |
+          echo "url=https://github.com/${{ github.repository }}/blob/gh-pages/${{ env.GH_PAGES_PATH }}/${{ env.LOG_NAME }}_summary.md" >> "$GITHUB_OUTPUT"
+
       - name: Cleanup Temp Directory
         if: always()
         run: |
@@ -407,6 +424,48 @@ jobs:
       - name: Path to result
         run: |
           echo "https://github.com/${{ github.repository }}/blob/gh-pages/${{ env.GH_PAGES_PATH }}/${{ env.LOG_NAME }}_summary.md"
+
+  report-to-source-pr:
+    if: ${{ always() && inputs.source_repository != '' && inputs.source_pr_number != '' }}
+    needs:
+      - check-gpu-mem-estimation
+      - benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment benchmark result on source PR
+        uses: actions/github-script@v7
+        env:
+          SOURCE_REPOSITORY: ${{ inputs.source_repository }}
+          SOURCE_PR_NUMBER: ${{ inputs.source_pr_number }}
+          CENO_VERSION: ${{ inputs.ceno_version != '' && inputs.ceno_version || 'pinned Cargo.toml version' }}
+          BENCHMARK_RESULT: ${{ needs.benchmark.result }}
+          BENCHMARK_RESULT_URL: ${{ needs.benchmark.outputs.result_url }}
+          MEM_RESULT: ${{ needs.check-gpu-mem-estimation.result }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.CENO_PR_COMMENT_TOKEN }}
+          script: |
+            const [owner, repo] = process.env.SOURCE_REPOSITORY.split("/");
+            const prNumber = Number(process.env.SOURCE_PR_NUMBER);
+            const benchmarkResult = process.env.BENCHMARK_RESULT || "skipped";
+            const memResult = process.env.MEM_RESULT || "skipped";
+            const lines = [
+              "Benchmark result from `scroll-tech/ceno-reth-benchmark`.",
+              "",
+              `- ceno version: \`${process.env.CENO_VERSION}\``,
+              `- benchmark job: \`${benchmarkResult}\``,
+              `- gpu mem estimation job: \`${memResult}\``,
+              `- workflow run: ${process.env.RUN_URL}`,
+            ];
+            if (process.env.BENCHMARK_RESULT_URL) {
+              lines.push(`- summary: ${process.env.BENCHMARK_RESULT_URL}`);
+            }
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: lines.join("\n"),
+            });
 #          fi
 #
 #          # Verify input file exists

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -101,6 +101,7 @@ jobs:
           export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
           set +e
           RUST_MIN_STACK=16777216 \
+          CENO_GPU_ENABLE_WITGEN=1 \
           CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
           RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
           cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -37,99 +37,99 @@ on:
         default: "false"
 
 jobs:
-  check-gpu-mem-estimation:
-    runs-on: [self-hosted, x64, linux, gpu]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2025-11-20 # keep it same with ceno repo
-          components: rust-src
-          cache: false
-
-      - name: Give Github Action access to ceno-gpu
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.SECRET_FOR_CENO_GPU }}
-
-      - name: Run GPU memory tracking benchmark
-        id: run_gpu_mem_verify
-        run: |
-          block_number="${{ inputs.block_number }}"
-          # Install Ceno CLI
-          echo "Installing Ceno CLI..."
-          CENO_VERSION="${{ inputs.ceno_version }}"
-          CENO_REF_FLAG="--rev ${CENO_VERSION}"
-          if git ls-remote --heads https://github.com/scroll-tech/ceno.git "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
-            echo "Detected branch '${CENO_VERSION}', installing via --branch"
-            CENO_REF_FLAG="--branch ${CENO_VERSION}"
-          else
-            echo "Installing via --rev ${CENO_VERSION}"
-          fi
-          cargo install --git https://github.com/scroll-tech/ceno.git \
-            ${CENO_REF_FLAG} \
-            --features jemalloc \
-            --features nightly-features \
-            --locked \
-            --force \
-            cargo-ceno
-
-          RPC_1=${{ secrets.RPC_URL_1 }}
-
-          # Build client binary
-          cd bin/ceno-client-eth
-          cargo ceno build --release
-
-          cd ../..
-
-          # Create necessary directories
-          mkdir -p output
-          mkdir -p rpc-cache
-
-          # LOG_NAME with Block number and Timestamp(UTC+8)
-          TIMESTAMP=$(date -u -d '+8 hours' +'%Y%m%d-%H%M%S')
-          LOG_NAME="gpu-mem-verify-mainnet${block_number}-${TIMESTAMP}"
-          LOG_FILE="${LOG_NAME}.log"
-          echo "LOG_NAME=${LOG_NAME}" >> $GITHUB_ENV
-          echo "LOG_FILE=${LOG_FILE}" >> $GITHUB_ENV
-
-          echo "Running GPU memory tracking benchmark for block $block_number..."
-          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
-          set +e
-
-          # Note: `CENO_GPU_MEM_TRACKING=1 CENO_CONCURRENT_CHIP_PROVING=0` to check GPU memory estimation
-          CENO_GPU_MEM_TRACKING=1 \
-          CENO_CONCURRENT_CHIP_PROVING=0 \
-          RUST_MIN_STACK=16777216 \
-          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
-          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
-          cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
-            --release --bin ceno-reth-benchmark-bin -- \
-            --mode prove-stark \
-            --block-number $block_number \
-            --rpc-url ${{ secrets.RPC_URL_1 }} \
-            --output-dir output \
-            --cache-dir rpc-cache > "$LOG_FILE" 2>&1
-          benchmark_status=$?
-          set -e
-          grep -v '\[ceno-gpu\]' "$LOG_FILE" # filter out ceno-gpu logs
-          if [ $benchmark_status -ne 0 ]; then
-            echo "GPU memory tracking benchmark failed with status $benchmark_status"
-            if [ "${{ inputs.ignore_failed }}" != "true" ]; then
-              exit $benchmark_status
-            fi
-            echo "Continuing despite failure because ignore_failed=true"
-          else
-            echo "GPU memory tracking benchmark completed successfully"
-          fi
+#  check-gpu-mem-estimation:
+#    runs-on: [self-hosted, x64, linux, gpu]
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v4
+#
+#      - name: Setup Rust
+#        uses: actions-rust-lang/setup-rust-toolchain@v1
+#        with:
+#          toolchain: nightly-2025-11-20 # keep it same with ceno repo
+#          components: rust-src
+#          cache: false
+#
+#      - name: Give Github Action access to ceno-gpu
+#        uses: webfactory/ssh-agent@v0.9.0
+#        with:
+#          ssh-private-key: |
+#            ${{ secrets.SECRET_FOR_CENO_GPU }}
+#
+#      - name: Run GPU memory tracking benchmark
+#        id: run_gpu_mem_verify
+#        run: |
+#          block_number="${{ inputs.block_number }}"
+#          # Install Ceno CLI
+#          echo "Installing Ceno CLI..."
+#          CENO_VERSION="${{ inputs.ceno_version }}"
+#          CENO_REF_FLAG="--rev ${CENO_VERSION}"
+#          if git ls-remote --heads https://github.com/scroll-tech/ceno.git "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
+#            echo "Detected branch '${CENO_VERSION}', installing via --branch"
+#            CENO_REF_FLAG="--branch ${CENO_VERSION}"
+#          else
+#            echo "Installing via --rev ${CENO_VERSION}"
+#          fi
+#          cargo install --git https://github.com/scroll-tech/ceno.git \
+#            ${CENO_REF_FLAG} \
+#            --features jemalloc \
+#            --features nightly-features \
+#            --locked \
+#            --force \
+#            cargo-ceno
+#
+#          RPC_1=${{ secrets.RPC_URL_1 }}
+#
+#          # Build client binary
+#          cd bin/ceno-client-eth
+#          cargo ceno build --release
+#
+#          cd ../..
+#
+#          # Create necessary directories
+#          mkdir -p output
+#          mkdir -p rpc-cache
+#
+#          # LOG_NAME with Block number and Timestamp(UTC+8)
+#          TIMESTAMP=$(date -u -d '+8 hours' +'%Y%m%d-%H%M%S')
+#          LOG_NAME="gpu-mem-verify-mainnet${block_number}-${TIMESTAMP}"
+#          LOG_FILE="${LOG_NAME}.log"
+#          echo "LOG_NAME=${LOG_NAME}" >> $GITHUB_ENV
+#          echo "LOG_FILE=${LOG_FILE}" >> $GITHUB_ENV
+#
+#          echo "Running GPU memory tracking benchmark for block $block_number..."
+#          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
+#          set +e
+#
+#          # Note: `CENO_GPU_MEM_TRACKING=1 CENO_CONCURRENT_CHIP_PROVING=0` to check GPU memory estimation
+#          CENO_GPU_MEM_TRACKING=1 \
+#          CENO_CONCURRENT_CHIP_PROVING=0 \
+#          RUST_MIN_STACK=16777216 \
+#          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
+#          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
+#          cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
+#            --release --bin ceno-reth-benchmark-bin -- \
+#            --mode prove-stark \
+#            --block-number $block_number \
+#            --rpc-url ${{ secrets.RPC_URL_1 }} \
+#            --output-dir output \
+#            --cache-dir rpc-cache > "$LOG_FILE" 2>&1
+#          benchmark_status=$?
+#          set -e
+#          grep -v '\[ceno-gpu\]' "$LOG_FILE" # filter out ceno-gpu logs
+#          if [ $benchmark_status -ne 0 ]; then
+#            echo "GPU memory tracking benchmark failed with status $benchmark_status"
+#            if [ "${{ inputs.ignore_failed }}" != "true" ]; then
+#              exit $benchmark_status
+#            fi
+#            echo "Continuing despite failure because ignore_failed=true"
+#          else
+#            echo "GPU memory tracking benchmark completed successfully"
+#          fi
 
   benchmark:
     runs-on: [self-hosted, x64, linux, gpu]
-    needs: check-gpu-mem-estimation
+    # needs: check-gpu-mem-estimation
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -35,101 +35,127 @@ on:
         required: false
         type: boolean
         default: "false"
+      run_gpu_benchmark:
+        description: "Run the GPU benchmark job"
+        required: false
+        type: boolean
+        default: "true"
+      run_gpu_mem_estimation:
+        description: "Run the GPU memory estimation check job"
+        required: false
+        type: boolean
+        default: "false"
+      gpu_enable_witgen:
+        description: "Value for CENO_GPU_ENABLE_WITGEN"
+        required: false
+        type: choice
+        default: "0"
+        options:
+          - "0"
+          - "1"
+      gpu_large_task_booking_margin_mb:
+        description: "Value for CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB"
+        required: false
+        type: string
+        default: "3048"
 
 jobs:
-#  check-gpu-mem-estimation:
-#    runs-on: [self-hosted, x64, linux, gpu]
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v4
-#
-#      - name: Setup Rust
-#        uses: actions-rust-lang/setup-rust-toolchain@v1
-#        with:
-#          toolchain: nightly-2025-11-20 # keep it same with ceno repo
-#          components: rust-src
-#          cache: false
-#
-#      - name: Give Github Action access to ceno-gpu
-#        uses: webfactory/ssh-agent@v0.9.0
-#        with:
-#          ssh-private-key: |
-#            ${{ secrets.SECRET_FOR_CENO_GPU }}
-#
-#      - name: Run GPU memory tracking benchmark
-#        id: run_gpu_mem_verify
-#        run: |
-#          block_number="${{ inputs.block_number }}"
-#          # Install Ceno CLI
-#          echo "Installing Ceno CLI..."
-#          CENO_VERSION="${{ inputs.ceno_version }}"
-#          CENO_REF_FLAG="--rev ${CENO_VERSION}"
-#          if git ls-remote --heads https://github.com/scroll-tech/ceno.git "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
-#            echo "Detected branch '${CENO_VERSION}', installing via --branch"
-#            CENO_REF_FLAG="--branch ${CENO_VERSION}"
-#          else
-#            echo "Installing via --rev ${CENO_VERSION}"
-#          fi
-#          cargo install --git https://github.com/scroll-tech/ceno.git \
-#            ${CENO_REF_FLAG} \
-#            --features jemalloc \
-#            --features nightly-features \
-#            --locked \
-#            --force \
-#            cargo-ceno
-#
-#          RPC_1=${{ secrets.RPC_URL_1 }}
-#
-#          # Build client binary
-#          cd bin/ceno-client-eth
-#          cargo ceno build --release
-#
-#          cd ../..
-#
-#          # Create necessary directories
-#          mkdir -p output
-#          mkdir -p rpc-cache
-#
-#          # LOG_NAME with Block number and Timestamp(UTC+8)
-#          TIMESTAMP=$(date -u -d '+8 hours' +'%Y%m%d-%H%M%S')
-#          LOG_NAME="gpu-mem-verify-mainnet${block_number}-${TIMESTAMP}"
-#          LOG_FILE="${LOG_NAME}.log"
-#          echo "LOG_NAME=${LOG_NAME}" >> $GITHUB_ENV
-#          echo "LOG_FILE=${LOG_FILE}" >> $GITHUB_ENV
-#
-#          echo "Running GPU memory tracking benchmark for block $block_number..."
-#          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
-#          set +e
-#
-#          # Note: `CENO_GPU_MEM_TRACKING=1 CENO_CONCURRENT_CHIP_PROVING=0` to check GPU memory estimation
-#          CENO_GPU_MEM_TRACKING=1 \
-#          CENO_CONCURRENT_CHIP_PROVING=0 \
-#          RUST_MIN_STACK=16777216 \
-#          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
-#          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
-#          cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
-#            --release --bin ceno-reth-benchmark-bin -- \
-#            --mode prove-stark \
-#            --block-number $block_number \
-#            --rpc-url ${{ secrets.RPC_URL_1 }} \
-#            --output-dir output \
-#            --cache-dir rpc-cache > "$LOG_FILE" 2>&1
-#          benchmark_status=$?
-#          set -e
-#          grep -v '\[ceno-gpu\]' "$LOG_FILE" # filter out ceno-gpu logs
-#          if [ $benchmark_status -ne 0 ]; then
-#            echo "GPU memory tracking benchmark failed with status $benchmark_status"
-#            if [ "${{ inputs.ignore_failed }}" != "true" ]; then
-#              exit $benchmark_status
-#            fi
-#            echo "Continuing despite failure because ignore_failed=true"
-#          else
-#            echo "GPU memory tracking benchmark completed successfully"
-#          fi
+  check-gpu-mem-estimation:
+    if: ${{ inputs.run_gpu_mem_estimation }}
+    runs-on: [self-hosted, x64, linux, gpu]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly-2025-11-20 # keep it same with ceno repo
+          components: rust-src
+          cache: false
+
+      - name: Give Github Action access to ceno-gpu
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.SECRET_FOR_CENO_GPU }}
+
+      - name: Run GPU memory tracking benchmark
+        id: run_gpu_mem_verify
+        run: |
+          block_number="${{ inputs.block_number }}"
+          # Install Ceno CLI
+          echo "Installing Ceno CLI..."
+          CENO_VERSION="${{ inputs.ceno_version }}"
+          CENO_REF_FLAG="--rev ${CENO_VERSION}"
+          if git ls-remote --heads https://github.com/scroll-tech/ceno.git "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
+            echo "Detected branch '${CENO_VERSION}', installing via --branch"
+            CENO_REF_FLAG="--branch ${CENO_VERSION}"
+          else
+            echo "Installing via --rev ${CENO_VERSION}"
+          fi
+          cargo install --git https://github.com/scroll-tech/ceno.git \
+            ${CENO_REF_FLAG} \
+            --features jemalloc \
+            --features nightly-features \
+            --locked \
+            --force \
+            cargo-ceno
+
+          RPC_1=${{ secrets.RPC_URL_1 }}
+
+          # Build client binary
+          cd bin/ceno-client-eth
+          cargo ceno build --release
+
+          cd ../..
+
+          # Create necessary directories
+          mkdir -p output
+          mkdir -p rpc-cache
+
+          # LOG_NAME with Block number and Timestamp(UTC+8)
+          TIMESTAMP=$(date -u -d '+8 hours' +'%Y%m%d-%H%M%S')
+          LOG_NAME="gpu-mem-verify-mainnet${block_number}-${TIMESTAMP}"
+          LOG_FILE="${LOG_NAME}.log"
+          echo "LOG_NAME=${LOG_NAME}" >> $GITHUB_ENV
+          echo "LOG_FILE=${LOG_FILE}" >> $GITHUB_ENV
+
+          echo "Running GPU memory tracking benchmark for block $block_number..."
+          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
+          set +e
+
+          # Note: `CENO_GPU_MEM_TRACKING=1 CENO_CONCURRENT_CHIP_PROVING=0` to check GPU memory estimation
+          CENO_GPU_MEM_TRACKING=1 \
+          CENO_CONCURRENT_CHIP_PROVING=0 \
+          CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB=${{ inputs.gpu_large_task_booking_margin_mb }} \
+          CENO_GPU_ENABLE_WITGEN=${{ inputs.gpu_enable_witgen }} \
+          RUST_MIN_STACK=16777216 \
+          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
+          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
+          cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
+            --release --bin ceno-reth-benchmark-bin -- \
+            --mode prove-stark \
+            --block-number $block_number \
+            --rpc-url ${{ secrets.RPC_URL_1 }} \
+            --output-dir output \
+            --cache-dir rpc-cache > "$LOG_FILE" 2>&1
+          benchmark_status=$?
+          set -e
+          grep -v '\[ceno-gpu\]' "$LOG_FILE" # filter out ceno-gpu logs
+          if [ $benchmark_status -ne 0 ]; then
+            echo "GPU memory tracking benchmark failed with status $benchmark_status"
+            if [ "${{ inputs.ignore_failed }}" != "true" ]; then
+              exit $benchmark_status
+            fi
+            echo "Continuing despite failure because ignore_failed=true"
+          else
+            echo "GPU memory tracking benchmark completed successfully"
+          fi
 
   benchmark:
+    if: ${{ inputs.run_gpu_benchmark }}
     runs-on: [self-hosted, x64, linux, gpu]
-    # needs: check-gpu-mem-estimation
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -191,8 +217,9 @@ jobs:
           echo "Generating e2e proof for block $block_number..."
           export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
           set +e
+          CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB=${{ inputs.gpu_large_task_booking_margin_mb }} \
           RUST_MIN_STACK=16777216 \
-          CENO_GPU_ENABLE_WITGEN=1 \
+          CENO_GPU_ENABLE_WITGEN=${{ inputs.gpu_enable_witgen }} \
           CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
           RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
           cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -37,8 +37,99 @@ on:
         default: "false"
 
 jobs:
+  check-gpu-mem-estimation:
+    runs-on: [self-hosted, x64, linux, gpu]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly-2025-11-20 # keep it same with ceno repo
+          components: rust-src
+          cache: false
+
+      - name: Give Github Action access to ceno-gpu
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.SECRET_FOR_CENO_GPU }}
+
+      - name: Run GPU memory tracking benchmark
+        id: run_gpu_mem_verify
+        run: |
+          block_number="${{ inputs.block_number }}"
+          # Install Ceno CLI
+          echo "Installing Ceno CLI..."
+          CENO_VERSION="${{ inputs.ceno_version }}"
+          CENO_REF_FLAG="--rev ${CENO_VERSION}"
+          if git ls-remote --heads https://github.com/scroll-tech/ceno.git "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
+            echo "Detected branch '${CENO_VERSION}', installing via --branch"
+            CENO_REF_FLAG="--branch ${CENO_VERSION}"
+          else
+            echo "Installing via --rev ${CENO_VERSION}"
+          fi
+          cargo install --git https://github.com/scroll-tech/ceno.git \
+            ${CENO_REF_FLAG} \
+            --features jemalloc \
+            --features nightly-features \
+            --locked \
+            --force \
+            cargo-ceno
+
+          RPC_1=${{ secrets.RPC_URL_1 }}
+
+          # Build client binary
+          cd bin/ceno-client-eth
+          cargo ceno build --release
+
+          cd ../..
+
+          # Create necessary directories
+          mkdir -p output
+          mkdir -p rpc-cache
+
+          # LOG_NAME with Block number and Timestamp(UTC+8)
+          TIMESTAMP=$(date -u -d '+8 hours' +'%Y%m%d-%H%M%S')
+          LOG_NAME="gpu-mem-verify-mainnet${block_number}-${TIMESTAMP}"
+          LOG_FILE="${LOG_NAME}.log"
+          echo "LOG_NAME=${LOG_NAME}" >> $GITHUB_ENV
+          echo "LOG_FILE=${LOG_FILE}" >> $GITHUB_ENV
+
+          echo "Running GPU memory tracking benchmark for block $block_number..."
+          export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
+          set +e
+
+          # Note: `CENO_GPU_MEM_TRACKING=1 CENO_CONCURRENT_CHIP_PROVING=0` to check GPU memory estimation
+          CENO_GPU_MEM_TRACKING=1 \
+          CENO_CONCURRENT_CHIP_PROVING=0 \
+          RUST_MIN_STACK=16777216 \
+          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
+          RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
+          cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
+            --release --bin ceno-reth-benchmark-bin -- \
+            --mode prove-stark \
+            --block-number $block_number \
+            --rpc-url ${{ secrets.RPC_URL_1 }} \
+            --output-dir output \
+            --cache-dir rpc-cache > "$LOG_FILE" 2>&1
+          benchmark_status=$?
+          set -e
+          grep -v '\[ceno-gpu\]' "$LOG_FILE" # filter out ceno-gpu logs
+          if [ $benchmark_status -ne 0 ]; then
+            echo "GPU memory tracking benchmark failed with status $benchmark_status"
+            if [ "${{ inputs.ignore_failed }}" != "true" ]; then
+              exit $benchmark_status
+            fi
+            echo "Continuing despite failure because ignore_failed=true"
+          else
+            echo "GPU memory tracking benchmark completed successfully"
+          fi
+
   benchmark:
     runs-on: [self-hosted, x64, linux, gpu]
+    needs: check-gpu-mem-estimation
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       ceno_version:
-        description: "Ceno version (commit sha) to benchmark"
-        required: true
+        description: "Ceno version (commit sha or branch) to benchmark; leave empty to use pinned Cargo.toml version"
+        required: false
         type: string
+        default: ""
       block_number:
         description: "Block number to generate input for"
         required: true
@@ -58,6 +59,22 @@ on:
         required: false
         type: string
         default: "3048"
+      concurrent_chip_proving:
+        description: "Value for CENO_CONCURRENT_CHIP_PROVING"
+        required: false
+        type: choice
+        default: "1"
+        options:
+          - "0"
+          - "1"
+      gpu_mem_tracking:
+        description: "Value for CENO_GPU_MEM_TRACKING"
+        required: false
+        type: choice
+        default: "0"
+        options:
+          - "0"
+          - "1"
 
 jobs:
   check-gpu-mem-estimation:
@@ -74,6 +91,28 @@ jobs:
           components: rust-src
           cache: false
 
+      - name: Resolve ceno source
+        run: |
+          python3 scripts/resolve_ceno_source.py \
+            --benchmark-root . \
+            --requested-ref "${{ inputs.ceno_version }}" >> "$GITHUB_ENV"
+
+      - name: Checkout ceno at requested version
+        if: ${{ env.CENO_USE_PINNED == 'false' }}
+        uses: actions/checkout@v4
+        with:
+          repository: scroll-tech/ceno
+          ref: ${{ env.CENO_REQUESTED_VERSION }}
+          path: ceno-src
+
+      - name: Patch local ceno dependencies
+        if: ${{ env.CENO_USE_PINNED == 'false' }}
+        run: |
+          python3 scripts/patch_ceno_pr_deps.py \
+            --benchmark-root . \
+            --ceno-root ./ceno-src \
+            --ceno-ref "${{ env.CENO_REQUESTED_VERSION }}"
+
       - name: Give Github Action access to ceno-gpu
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -86,21 +125,30 @@ jobs:
           block_number="${{ inputs.block_number }}"
           # Install Ceno CLI
           echo "Installing Ceno CLI..."
-          CENO_VERSION="${{ inputs.ceno_version }}"
-          CENO_REF_FLAG="--rev ${CENO_VERSION}"
-          if git ls-remote --heads https://github.com/scroll-tech/ceno.git "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
-            echo "Detected branch '${CENO_VERSION}', installing via --branch"
-            CENO_REF_FLAG="--branch ${CENO_VERSION}"
+          if [ "${CENO_USE_PINNED}" = "true" ]; then
+            echo "Using pinned ceno_cli source from Cargo.toml"
+            CENO_GIT_URL="${CENO_PINNED_GIT}"
+            CENO_PACKAGE="${CENO_PINNED_PACKAGE}"
+            CENO_REF_FLAG="--${CENO_PINNED_REF_KIND} ${CENO_PINNED_REF_VALUE}"
           else
-            echo "Installing via --rev ${CENO_VERSION}"
+            CENO_VERSION="${CENO_REQUESTED_VERSION}"
+            CENO_GIT_URL="https://github.com/scroll-tech/ceno.git"
+            CENO_PACKAGE="cargo-ceno"
+            CENO_REF_FLAG="--rev ${CENO_VERSION}"
+            if git ls-remote --heads "${CENO_GIT_URL}" "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
+              echo "Detected branch '${CENO_VERSION}', installing via --branch"
+              CENO_REF_FLAG="--branch ${CENO_VERSION}"
+            else
+              echo "Installing via --rev ${CENO_VERSION}"
+            fi
           fi
-          cargo install --git https://github.com/scroll-tech/ceno.git \
+          cargo install --git "${CENO_GIT_URL}" \
             ${CENO_REF_FLAG} \
             --features jemalloc \
             --features nightly-features \
             --locked \
             --force \
-            cargo-ceno
+            "${CENO_PACKAGE}"
 
           RPC_1=${{ secrets.RPC_URL_1 }}
 
@@ -126,8 +174,8 @@ jobs:
           set +e
 
           # Note: `CENO_GPU_MEM_TRACKING=1 CENO_CONCURRENT_CHIP_PROVING=0` to check GPU memory estimation
-          CENO_GPU_MEM_TRACKING=1 \
-          CENO_CONCURRENT_CHIP_PROVING=0 \
+          CENO_GPU_MEM_TRACKING=${{ inputs.gpu_mem_tracking }} \
+          CENO_CONCURRENT_CHIP_PROVING=${{ inputs.concurrent_chip_proving }} \
           CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB=${{ inputs.gpu_large_task_booking_margin_mb }} \
           CENO_GPU_ENABLE_WITGEN=${{ inputs.gpu_enable_witgen }} \
           RUST_MIN_STACK=16777216 \
@@ -167,6 +215,28 @@ jobs:
           components: rust-src
           cache: false
 
+      - name: Resolve ceno source
+        run: |
+          python3 scripts/resolve_ceno_source.py \
+            --benchmark-root . \
+            --requested-ref "${{ inputs.ceno_version }}" >> "$GITHUB_ENV"
+
+      - name: Checkout ceno at requested version
+        if: ${{ env.CENO_USE_PINNED == 'false' }}
+        uses: actions/checkout@v4
+        with:
+          repository: scroll-tech/ceno
+          ref: ${{ env.CENO_REQUESTED_VERSION }}
+          path: ceno-src
+
+      - name: Patch local ceno dependencies
+        if: ${{ env.CENO_USE_PINNED == 'false' }}
+        run: |
+          python3 scripts/patch_ceno_pr_deps.py \
+            --benchmark-root . \
+            --ceno-root ./ceno-src \
+            --ceno-ref "${{ env.CENO_REQUESTED_VERSION }}"
+
       - name: Give Github Action access to ceno-gpu
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -179,21 +249,30 @@ jobs:
           block_number="${{ inputs.block_number }}"
           # Install Ceno CLI
           echo "Installing Ceno CLI..."
-          CENO_VERSION="${{ inputs.ceno_version }}"
-          CENO_REF_FLAG="--rev ${CENO_VERSION}"
-          if git ls-remote --heads https://github.com/scroll-tech/ceno.git "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
-            echo "Detected branch '${CENO_VERSION}', installing via --branch"
-            CENO_REF_FLAG="--branch ${CENO_VERSION}"
+          if [ "${CENO_USE_PINNED}" = "true" ]; then
+            echo "Using pinned ceno_cli source from Cargo.toml"
+            CENO_GIT_URL="${CENO_PINNED_GIT}"
+            CENO_PACKAGE="${CENO_PINNED_PACKAGE}"
+            CENO_REF_FLAG="--${CENO_PINNED_REF_KIND} ${CENO_PINNED_REF_VALUE}"
           else
-            echo "Installing via --rev ${CENO_VERSION}"
+            CENO_VERSION="${CENO_REQUESTED_VERSION}"
+            CENO_GIT_URL="https://github.com/scroll-tech/ceno.git"
+            CENO_PACKAGE="cargo-ceno"
+            CENO_REF_FLAG="--rev ${CENO_VERSION}"
+            if git ls-remote --heads "${CENO_GIT_URL}" "${CENO_VERSION}" | grep -q "${CENO_VERSION}"; then
+              echo "Detected branch '${CENO_VERSION}', installing via --branch"
+              CENO_REF_FLAG="--branch ${CENO_VERSION}"
+            else
+              echo "Installing via --rev ${CENO_VERSION}"
+            fi
           fi
-          cargo install --git https://github.com/scroll-tech/ceno.git \
+          cargo install --git "${CENO_GIT_URL}" \
             ${CENO_REF_FLAG} \
             --features jemalloc \
             --features nightly-features \
             --locked \
             --force \
-            cargo-ceno
+            "${CENO_PACKAGE}"
 
           RPC_1=${{ secrets.RPC_URL_1 }}
 
@@ -217,6 +296,8 @@ jobs:
           echo "Generating e2e proof for block $block_number..."
           export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
           set +e
+          CENO_GPU_MEM_TRACKING=${{ inputs.gpu_mem_tracking }} \
+          CENO_CONCURRENT_CHIP_PROVING=${{ inputs.concurrent_chip_proving }} \
           CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB=${{ inputs.gpu_large_task_booking_margin_mb }} \
           RUST_MIN_STACK=16777216 \
           CENO_GPU_ENABLE_WITGEN=${{ inputs.gpu_enable_witgen }} \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#256c96db98c02f13c48be0cbdd91145c6aeb29af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2179029c1bd77db4e883507ae0b0d01708a002a4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2ed2edfded7ad091ee2e14c8b505d6191c0155d5"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2179029c1bd77db4e883507ae0b0d01708a002a4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2ed2edfded7ad091ee2e14c8b505d6191c0155d5"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2179029c1bd77db4e883507ae0b0d01708a002a4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2ed2edfded7ad091ee2e14c8b505d6191c0155d5"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#c71981af766724ed73e047ebb7381433796b8645"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#c71981af766724ed73e047ebb7381433796b8645"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#c71981af766724ed73e047ebb7381433796b8645"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#c71981af766724ed73e047ebb7381433796b8645"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#c71981af766724ed73e047ebb7381433796b8645"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#c71981af766724ed73e047ebb7381433796b8645"
 dependencies = [
  "cc",
  "ff_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#affab95fc1edb2c4555adc52f2ae7abb3a4e312f"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#de3080533b3dbe82dbd44c18b4dd23ebccfd72ab"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -3092,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7625,7 +7625,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8891,7 +8891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#affab95fc1edb2c4555adc52f2ae7abb3a4e312f"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#de3080533b3dbe82dbd44c18b4dd23ebccfd72ab"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#affab95fc1edb2c4555adc52f2ae7abb3a4e312f"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#de3080533b3dbe82dbd44c18b4dd23ebccfd72ab"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9872,7 +9872,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2d8eb44da74b533d57ad73f7e7163ba313ee4866"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ffaaa733d52c8289569c8b22fb1f3db86f4aeaac"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3092,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "once_cell",
  "p3",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -4435,7 +4435,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -4990,7 +4990,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "either",
  "ff_ext",
@@ -5038,7 +5038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -7363,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "ff_ext",
  "p3",
@@ -7625,7 +7625,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2d8eb44da74b533d57ad73f7e7163ba313ee4866"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ffaaa733d52c8289569c8b22fb1f3db86f4aeaac"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2d8eb44da74b533d57ad73f7e7163ba313ee4866"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ffaaa733d52c8289569c8b22fb1f3db86f4aeaac"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9702,7 +9702,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "either",
  "ff_ext",
@@ -9720,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -9872,7 +9872,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -10830,7 +10830,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11166,7 +11166,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#0b982647717896aab14320e82c5e415c05449be4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2179029c1bd77db4e883507ae0b0d01708a002a4"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#854027ddb0f33d17ba250a61a1a1f514869cde8f"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#0b982647717896aab14320e82c5e415c05449be4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2179029c1bd77db4e883507ae0b0d01708a002a4"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#0b982647717896aab14320e82c5e415c05449be4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2179029c1bd77db4e883507ae0b0d01708a002a4"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#c2f65c56923bf774acd72f19483ac650cb2f1765"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#61f7d6a72958ad2e001da9f2ef5633f991970459"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#c2f65c56923bf774acd72f19483ac650cb2f1765"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#61f7d6a72958ad2e001da9f2ef5633f991970459"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#c2f65c56923bf774acd72f19483ac650cb2f1765"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#61f7d6a72958ad2e001da9f2ef5633f991970459"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#cfaee5897a3223675f18cc7530323a0a5ac11b46"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#3efbce91a07ded144b68240d2924a3f85c2c6e80"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#cfaee5897a3223675f18cc7530323a0a5ac11b46"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#3efbce91a07ded144b68240d2924a3f85c2c6e80"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#cfaee5897a3223675f18cc7530323a0a5ac11b46"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#3efbce91a07ded144b68240d2924a3f85c2c6e80"
 dependencies = [
  "cc",
  "ff_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#faafc9373930a3f5716a8bafa5629447eff66023"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#97808cf488ce4a61337bb989c56d2cef331e03bf"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#faafc9373930a3f5716a8bafa5629447eff66023"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#97808cf488ce4a61337bb989c56d2cef331e03bf"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#faafc9373930a3f5716a8bafa5629447eff66023"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#97808cf488ce4a61337bb989c56d2cef331e03bf"
 dependencies = [
  "cc",
  "ff_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#feaf54f933bcb2dbe58ad03996494dd2628dcab9"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#28c3f1d5df11bfb89b1e0a9b92f0a44eae0c8298"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#feaf54f933bcb2dbe58ad03996494dd2628dcab9"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#28c3f1d5df11bfb89b1e0a9b92f0a44eae0c8298"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#feaf54f933bcb2dbe58ad03996494dd2628dcab9"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#28c3f1d5df11bfb89b1e0a9b92f0a44eae0c8298"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ee7997c7384df9f1734b3e1fb57f4c7ec6e3f963"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#71b9779179e4ee27a6ff1d8603a53c628f1f3f0d"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#7c236b25654473881173619af0e2c8b7dbf46093"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#71b9779179e4ee27a6ff1d8603a53c628f1f3f0d"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#7c236b25654473881173619af0e2c8b7dbf46093"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#71b9779179e4ee27a6ff1d8603a53c628f1f3f0d"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#7c236b25654473881173619af0e2c8b7dbf46093"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#de3080533b3dbe82dbd44c18b4dd23ebccfd72ab"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#ecbea3e56a7501c8e7ae14c30ec2163008e0e868"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -3092,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7625,7 +7625,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8891,7 +8891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#de3080533b3dbe82dbd44c18b4dd23ebccfd72ab"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#ecbea3e56a7501c8e7ae14c30ec2163008e0e868"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#de3080533b3dbe82dbd44c18b4dd23ebccfd72ab"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#ecbea3e56a7501c8e7ae14c30ec2163008e0e868"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9872,7 +9872,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#563c3f8fda3a417fe0b32579f52921471f167cbe"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#b664c0a5fb91e7689e70abcf1c75fc24a700d18d"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#6e7f31ad72826210e91e47a0c695c7ec9a5986ca"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#563c3f8fda3a417fe0b32579f52921471f167cbe"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#b664c0a5fb91e7689e70abcf1c75fc24a700d18d"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#563c3f8fda3a417fe0b32579f52921471f167cbe"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#b664c0a5fb91e7689e70abcf1c75fc24a700d18d"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#067f89ddcbbcf92b26376bdcb2d767db800688bd"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#dc04d284c3fd392efcbdaedb20d23249afd89015"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2db2e3cc7c5cd2dfe7ab6debf185c5a252ef1bfe"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#067f89ddcbbcf92b26376bdcb2d767db800688bd"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#dc04d284c3fd392efcbdaedb20d23249afd89015"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#067f89ddcbbcf92b26376bdcb2d767db800688bd"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#dc04d284c3fd392efcbdaedb20d23249afd89015"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2ed2edfded7ad091ee2e14c8b505d6191c0155d5"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#71b9779179e4ee27a6ff1d8603a53c628f1f3f0d"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2ed2edfded7ad091ee2e14c8b505d6191c0155d5"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#71b9779179e4ee27a6ff1d8603a53c628f1f3f0d"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#2ed2edfded7ad091ee2e14c8b505d6191c0155d5"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#71b9779179e4ee27a6ff1d8603a53c628f1f3f0d"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#3efbce91a07ded144b68240d2924a3f85c2c6e80"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#affab95fc1edb2c4555adc52f2ae7abb3a4e312f"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -3092,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7625,7 +7625,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8891,7 +8891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#3efbce91a07ded144b68240d2924a3f85c2c6e80"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#affab95fc1edb2c4555adc52f2ae7abb3a4e312f"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#3efbce91a07ded144b68240d2924a3f85c2c6e80"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#affab95fc1edb2c4555adc52f2ae7abb3a4e312f"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9872,7 +9872,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ffaaa733d52c8289569c8b22fb1f3db86f4aeaac"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#faafc9373930a3f5716a8bafa5629447eff66023"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c46a574a7c66e5826b3afc82318af07a737418a8"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ffaaa733d52c8289569c8b22fb1f3db86f4aeaac"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#faafc9373930a3f5716a8bafa5629447eff66023"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ffaaa733d52c8289569c8b22fb1f3db86f4aeaac"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#faafc9373930a3f5716a8bafa5629447eff66023"
 dependencies = [
  "cc",
  "ff_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#7c236b25654473881173619af0e2c8b7dbf46093"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#563c3f8fda3a417fe0b32579f52921471f167cbe"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#7c236b25654473881173619af0e2c8b7dbf46093"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#563c3f8fda3a417fe0b32579f52921471f167cbe"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#7c236b25654473881173619af0e2c8b7dbf46093"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#563c3f8fda3a417fe0b32579f52921471f167cbe"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#b664c0a5fb91e7689e70abcf1c75fc24a700d18d"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ed22a756c72547a9f3c6507dd979d79d98f199c4"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#b664c0a5fb91e7689e70abcf1c75fc24a700d18d"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ed22a756c72547a9f3c6507dd979d79d98f199c4"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#b664c0a5fb91e7689e70abcf1c75fc24a700d18d"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ed22a756c72547a9f3c6507dd979d79d98f199c4"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#169a89edc8f7fc4324b541d2f66aad04804930da"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#cfaee5897a3223675f18cc7530323a0a5ac11b46"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -3092,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8891,7 +8891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#169a89edc8f7fc4324b541d2f66aad04804930da"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#cfaee5897a3223675f18cc7530323a0a5ac11b46"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#169a89edc8f7fc4324b541d2f66aad04804930da"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#cfaee5897a3223675f18cc7530323a0a5ac11b46"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9872,7 +9872,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10830,7 +10830,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#369365422d35e2ab5ce6a46052bdf2ba0ac5158b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#fcd98f265459fc1071b26354ebdfd4d1f1c08e01"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#f3949b50296a53db675d85615ffb424915928c3e"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ed22a756c72547a9f3c6507dd979d79d98f199c4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#feaf54f933bcb2dbe58ad03996494dd2628dcab9"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#ae3ba76d1f04b5e63d6ebea3cf63112ee613b4af"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ed22a756c72547a9f3c6507dd979d79d98f199c4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#feaf54f933bcb2dbe58ad03996494dd2628dcab9"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#ed22a756c72547a9f3c6507dd979d79d98f199c4"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#feaf54f933bcb2dbe58ad03996494dd2628dcab9"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#ecbea3e56a7501c8e7ae14c30ec2163008e0e868"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#06c557d4d7bb98ee4883ce72a6e1670bf013ab18"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -3092,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7625,7 +7625,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8891,7 +8891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#ecbea3e56a7501c8e7ae14c30ec2163008e0e868"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#06c557d4d7bb98ee4883ce72a6e1670bf013ab18"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#ecbea3e56a7501c8e7ae14c30ec2163008e0e868"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#06c557d4d7bb98ee4883ce72a6e1670bf013ab18"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9872,7 +9872,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#95589d2ff89a1c72d59cb3d62fe53f3b5b370cf1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#bcf9d26e886dded93f4f47fffea8764983ca370d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#c88436b8603ca205691df654551259e48501e738"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#38420988733481c9cd384eb03ae03c911a2e37e5"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#305778ad90f1e8ae8b125c695398b8f6006df794"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#ee985f5a3f0c5ad3043d860284b2a377ffe16807"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#1c24d976ccaf5e53687da99f892b4ef23e3c6cd9"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#dc04d284c3fd392efcbdaedb20d23249afd89015"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#c2f65c56923bf774acd72f19483ac650cb2f1765"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#326e5173ccd6db8b7b11fd8c2793252c47bd05d1"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#98b1a7d7b1c2a48229efda025113daacd32d4d6d"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#dc04d284c3fd392efcbdaedb20d23249afd89015"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#c2f65c56923bf774acd72f19483ac650cb2f1765"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#dc04d284c3fd392efcbdaedb20d23249afd89015"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#c2f65c56923bf774acd72f19483ac650cb2f1765"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#68aef1dbb0c047474bb9ee3d9cb79afbd8206387"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#993566f41b1672620da215922e4a79332dcb29b1"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#5bfe1faaeaa334852b6474b86504249750cb6574"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#28c3f1d5df11bfb89b1e0a9b92f0a44eae0c8298"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#067f89ddcbbcf92b26376bdcb2d767db800688bd"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#29057ae81e98da099fd2cdd57f745f66c01f99b6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#28c3f1d5df11bfb89b1e0a9b92f0a44eae0c8298"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#067f89ddcbbcf92b26376bdcb2d767db800688bd"
 dependencies = [
  "cc",
  "which",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#28c3f1d5df11bfb89b1e0a9b92f0a44eae0c8298"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#067f89ddcbbcf92b26376bdcb2d767db800688bd"
 dependencies = [
  "cc",
  "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2c8979e2e5c34118105cda8cb8f7e6fd14172f33"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#c71981af766724ed73e047ebb7381433796b8645"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#2cc59b447ba999703f21b1ae963a8ddb5668da5e"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2c8979e2e5c34118105cda8cb8f7e6fd14172f33"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#c71981af766724ed73e047ebb7381433796b8645"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2c8979e2e5c34118105cda8cb8f7e6fd14172f33"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#c71981af766724ed73e047ebb7381433796b8645"
 dependencies = [
  "cc",
  "ff_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#3f64eaaa6d72c7842ab82ad7936b466083abb9cd"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#282cbc269c1d013d93ddf615c9c5909fb88cae0e"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#2390d585a9be2d6a9955e5738b4ce6997880b8d0"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#280f9b9ff8633d0048b3bfc6a41562aadddcb6e3"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch?branch=main#6e90bc85bcee
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#76c8be898631011ad114e2508d78a83fbda73378"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#169a89edc8f7fc4324b541d2f66aad04804930da"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#e33cca0738ac6e9dba1266c50ddad7d8ef8a7515"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -3660,6 +3660,7 @@ dependencies = [
  "p3",
  "rand 0.8.5",
  "rayon",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "strum 0.26.3",
@@ -9582,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#76c8be898631011ad114e2508d78a83fbda73378"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#169a89edc8f7fc4324b541d2f66aad04804930da"
 dependencies = [
  "cc",
  "which",
@@ -9591,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#76c8be898631011ad114e2508d78a83fbda73378"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#169a89edc8f7fc4324b541d2f66aad04804930da"
 dependencies = [
  "cc",
  "ff_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "glob",
 ]
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "ceno_crypto_primitives"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno-patch?branch=main#6e90bc85bceefe09003f84ca5cc1afbe2911a2db"
+source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85bceefe09003f84ca5cc1afbe2911a2db"
 dependencies = [
  "ceno_syscall",
  "elliptic-curve",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1958,12 +1958,12 @@ dependencies = [
 [[package]]
 name = "ceno_syscall"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno-patch?branch=main#6e90bc85bceefe09003f84ca5cc1afbe2911a2db"
+source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85bceefe09003f84ca5cc1afbe2911a2db"
 
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_fix#fe5d15f0aa0e490eeb3beb5e7d364e494ade2be2"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#7090881030ed8ee947fa92c05eafd97a94436fa2"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#dc6f7e9f0c96f8cd28ccff82eaab20d5c8cc5529"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#319f7f48ace228353098d98310566f5b1c10e804"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#b41baea5ef0b1ee5f1f867566aba9873a01c620b"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#1bf0485609656dc5ab9d238ccf1079756d23674e"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#9c98a33a6204ae166648c9211175081be98100f6"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1674,10 +1674,10 @@ dependencies = [
  "ceno_zkvm",
  "clap",
  "console",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "get_dir",
  "gkr_iop",
- "mpcs",
+ "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "openvm-circuit",
  "openvm-continuations",
  "openvm-cuda-backend",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "glob",
 ]
@@ -1847,16 +1847,16 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "anyhow",
  "ceno_rt",
  "ceno_syscall",
  "elf",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "itertools 0.13.0",
  "k256 0.13.4 (git+https://github.com/scroll-tech/elliptic-curves?branch=ceno%2Fk256-13.4)",
- "multilinear_extensions",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "num",
  "num-derive",
  "num-traits",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1901,11 +1901,11 @@ dependencies = [
  "ceno_host",
  "ceno_zkvm",
  "clap",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "gkr_iop",
  "itertools 0.13.0",
- "mpcs",
- "multilinear_extensions",
+ "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "openvm",
  "openvm-circuit",
  "openvm-continuations",
@@ -1919,24 +1919,24 @@ dependencies = [
  "openvm-sdk",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "parse-size",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sumcheck",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.22",
- "transcript",
- "whir",
- "witness",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
 ]
 
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -1977,20 +1977,20 @@ dependencies = [
  "cuda_hal",
  "derive",
  "either",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "generic-array 1.3.5",
  "generic_static",
  "gkr_iop",
  "glob",
  "itertools 0.13.0",
  "metrics",
- "mpcs",
- "multilinear_extensions",
+ "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "ndarray",
  "num",
  "num-bigint 0.4.6",
  "once_cell",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "parse-size",
  "prettytable-rs",
  "rand 0.8.5",
@@ -2002,7 +2002,7 @@ dependencies = [
  "sp1-curves",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "sumcheck",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
@@ -2010,10 +2010,10 @@ dependencies = [
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.22",
- "transcript",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "typenum",
- "whir",
- "witness",
+ "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
 ]
 
 [[package]]
@@ -2431,27 +2431,27 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#97808cf488ce4a61337bb989c56d2cef331e03bf"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#0b982647717896aab14320e82c5e415c05449be4"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
  "cudarc",
  "downcast-rs",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "itertools 0.13.0",
- "mpcs",
- "multilinear_extensions",
- "p3",
+ "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "rand 0.8.5",
  "rayon",
  "sha2 0.10.9",
  "sppark",
  "sppark_plug",
- "sumcheck",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "thiserror 1.0.69",
  "tracing",
- "transcript",
- "witness",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
 ]
 
 [[package]]
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3301,10 +3301,21 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "once_cell",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
+name = "ff_ext"
+version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "once_cell",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "rand_core 0.6.4",
  "serde",
 ]
@@ -3646,18 +3657,18 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#490993aaddec318ec777a9a26d0d261f981a175c"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#0db05c32df14161ac7d68c09d9648da52b4a48d8"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
  "cudarc",
  "either",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "itertools 0.13.0",
- "mpcs",
- "multilinear_extensions",
+ "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "once_cell",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "rand 0.8.5",
  "rayon",
  "rustc-hash 2.1.1",
@@ -3665,14 +3676,14 @@ dependencies = [
  "smallvec",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "sumcheck",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "thiserror 2.0.17",
  "thread_local",
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.22",
- "transcript",
- "witness",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
 ]
 
 [[package]]
@@ -4966,25 +4977,64 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "bincode 1.3.3",
  "clap",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "itertools 0.13.0",
- "multilinear_extensions",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "num-integer",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "sumcheck",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "tracing",
  "tracing-subscriber 0.3.22",
- "transcript",
- "whir",
- "witness",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+]
+
+[[package]]
+name = "mpcs"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+dependencies = [
+ "bincode 1.3.3",
+ "clap",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "itertools 0.13.0",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "num-integer",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+]
+
+[[package]]
+name = "multilinear_extensions"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "either",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "itertools 0.13.0",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -4993,9 +5043,9 @@ version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "either",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "itertools 0.13.0",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -6238,12 +6288,12 @@ dependencies = [
  "derive_more 1.0.0",
  "dotenv",
  "eyre",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "gkr_iop",
  "halo2-axiom",
  "hex",
  "metrics",
- "mpcs",
+ "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-benchmarks-prove",
@@ -6617,6 +6667,31 @@ dependencies = [
  "elliptic-curve",
  "primeorder 0.13.6 (git+https://github.com/scroll-tech/elliptic-curves?branch=ceno%2Fk256-13.4)",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p3"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "p3-air",
+ "p3-baby-bear",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-fri",
+ "p3-goldilocks",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-mds",
+ "p3-merkle-tree",
+ "p3-monty-31",
+ "p3-poseidon",
+ "p3-poseidon2",
+ "p3-poseidon2-air",
+ "p3-symmetric",
+ "p3-util",
 ]
 
 [[package]]
@@ -7363,10 +7438,20 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "serde",
+]
+
+[[package]]
+name = "poseidon"
+version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
- "ff_ext",
- "p3",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "serde",
 ]
 
@@ -9545,16 +9630,16 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "cfg-if",
  "dashu",
  "elliptic-curve",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "generic-array 1.3.5",
  "itertools 0.13.0",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "multilinear_extensions",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "num",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "p3-field",
@@ -9583,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#97808cf488ce4a61337bb989c56d2cef331e03bf"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#0b982647717896aab14320e82c5e415c05449be4"
 dependencies = [
  "cc",
  "which",
@@ -9592,12 +9677,12 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#97808cf488ce4a61337bb989c56d2cef331e03bf"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#0b982647717896aab14320e82c5e415c05449be4"
 dependencies = [
  "cc",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "itertools 0.13.0",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
  "sppark",
 ]
 
@@ -9702,19 +9787,50 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "either",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "itertools 0.13.0",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "rayon",
+ "serde",
+ "sumcheck_macro 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "thiserror 1.0.69",
+ "tracing",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+]
+
+[[package]]
+name = "sumcheck"
+version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "either",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "itertools 0.13.0",
- "multilinear_extensions",
- "p3",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "rayon",
  "serde",
- "sumcheck_macro",
+ "sumcheck_macro 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "thiserror 1.0.69",
  "tracing",
- "transcript",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+]
+
+[[package]]
+name = "sumcheck_macro"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "itertools 0.13.0",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "proc-macro2",
+ "quote",
+ "rand 0.8.5",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9723,7 +9839,7 @@ version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "itertools 0.13.0",
- "p3",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "proc-macro2",
  "quote",
  "rand 0.8.5",
@@ -10412,12 +10528,23 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "itertools 0.13.0",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "poseidon 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+]
+
+[[package]]
+name = "transcript"
+version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "itertools 0.13.0",
- "p3",
- "poseidon",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "poseidon 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
 ]
 
 [[package]]
@@ -10788,24 +10915,47 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "bincode 1.3.3",
+ "clap",
+ "derive_more 1.0.0",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "itertools 0.14.0",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "tracing",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "transpose",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+]
+
+[[package]]
+name = "whir"
+version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "bincode 1.3.3",
  "clap",
  "derive_more 1.0.0",
- "ff_ext",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "itertools 0.14.0",
- "multilinear_extensions",
- "p3",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "sumcheck",
+ "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "tracing",
- "transcript",
+ "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "transpose",
- "witness",
+ "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
 ]
 
 [[package]]
@@ -11166,11 +11316,24 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "witness"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+dependencies = [
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "rand 0.8.5",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
+name = "witness"
+version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
- "ff_ext",
- "multilinear_extensions",
- "p3",
+ "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
  "rand 0.8.5",
  "rayon",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#06c557d4d7bb98ee4883ce72a6e1670bf013ab18"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2d8eb44da74b533d57ad73f7e7163ba313ee4866"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3092,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#beb98a266bcd34bf3f01f07557454bf8af32c741"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#dabed5af334542aa11ba7c422abbb4469467ae9a"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -4435,7 +4435,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7625,7 +7625,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8891,7 +8891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#06c557d4d7bb98ee4883ce72a6e1670bf013ab18"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2d8eb44da74b533d57ad73f7e7163ba313ee4866"
 dependencies = [
  "cc",
  "which",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#06c557d4d7bb98ee4883ce72a6e1670bf013ab18"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2d8eb44da74b533d57ad73f7e7163ba313ee4866"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9872,7 +9872,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#a0a2553aae06dab4fac2a902b08a68ac3b0247bf"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#4e3c9c884bab37cd33451dd7a6b33c01d1dcd27b"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1674,10 +1674,10 @@ dependencies = [
  "ceno_zkvm",
  "clap",
  "console",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "get_dir",
  "gkr_iop",
- "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "mpcs",
  "openvm-circuit",
  "openvm-continuations",
  "openvm-cuda-backend",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "glob",
 ]
@@ -1847,16 +1847,16 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "anyhow",
  "ceno_rt",
  "ceno_syscall",
  "elf",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
  "k256 0.13.4 (git+https://github.com/scroll-tech/elliptic-curves?branch=ceno%2Fk256-13.4)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions",
  "num",
  "num-derive",
  "num-traits",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1901,11 +1901,11 @@ dependencies = [
  "ceno_host",
  "ceno_zkvm",
  "clap",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "gkr_iop",
  "itertools 0.13.0",
- "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "mpcs",
+ "multilinear_extensions",
  "openvm",
  "openvm-circuit",
  "openvm-continuations",
@@ -1919,24 +1919,24 @@ dependencies = [
  "openvm-sdk",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3",
  "parse-size",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "sumcheck",
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.22",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "transcript",
+ "whir",
+ "witness",
 ]
 
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -1977,20 +1977,20 @@ dependencies = [
  "cuda_hal",
  "derive",
  "either",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "generic-array 1.3.5",
  "generic_static",
  "gkr_iop",
  "glob",
  "itertools 0.13.0",
  "metrics",
- "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "mpcs",
+ "multilinear_extensions",
  "ndarray",
  "num",
  "num-bigint 0.4.6",
  "once_cell",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3",
  "parse-size",
  "prettytable-rs",
  "rand 0.8.5",
@@ -2002,7 +2002,7 @@ dependencies = [
  "sp1-curves",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "sumcheck",
  "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
@@ -2010,10 +2010,10 @@ dependencies = [
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.22",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "transcript",
  "typenum",
- "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "whir",
+ "witness",
 ]
 
 [[package]]
@@ -2431,27 +2431,27 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#61f7d6a72958ad2e001da9f2ef5633f991970459"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2c8979e2e5c34118105cda8cb8f7e6fd14172f33"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
  "cudarc",
  "downcast-rs",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
- "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "mpcs",
+ "multilinear_extensions",
+ "p3",
  "rand 0.8.5",
  "rayon",
  "sha2 0.10.9",
  "sppark",
  "sppark_plug",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "sumcheck",
  "thiserror 1.0.69",
  "tracing",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "transcript",
+ "witness",
 ]
 
 [[package]]
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3301,21 +3301,10 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "once_cell",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "rand_core 0.6.4",
- "serde",
-]
-
-[[package]]
-name = "ff_ext"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "once_cell",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3",
  "rand_core 0.6.4",
  "serde",
 ]
@@ -3657,18 +3646,18 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen_flow#01ccc6a168b52f0406bd2d061f91ab5412524f17"
+source = "git+https://github.com/scroll-tech/ceno?branch=feat%2Fgpu-witnessgen#23dc474229f34b0add6544d562cdd98fbf6b2a1b"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
  "cudarc",
  "either",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
- "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "mpcs",
+ "multilinear_extensions",
  "once_cell",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3",
  "rand 0.8.5",
  "rayon",
  "rustc-hash 2.1.1",
@@ -3676,14 +3665,14 @@ dependencies = [
  "smallvec",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "sumcheck",
  "thiserror 2.0.17",
  "thread_local",
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.22",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "transcript",
+ "witness",
 ]
 
 [[package]]
@@ -4977,75 +4966,36 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "bincode 1.3.3",
  "clap",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions",
  "num-integer",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "sumcheck",
  "tracing",
  "tracing-subscriber 0.3.22",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
-]
-
-[[package]]
-name = "mpcs"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "bincode 1.3.3",
- "clap",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "itertools 0.13.0",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "num-integer",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rayon",
- "serde",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "tracing",
- "tracing-subscriber 0.3.22",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "whir 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "transcript",
+ "whir",
+ "witness",
 ]
 
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "either",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "rand 0.8.5",
- "rayon",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "multilinear_extensions"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "either",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "itertools 0.13.0",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -6288,12 +6238,12 @@ dependencies = [
  "derive_more 1.0.0",
  "dotenv",
  "eyre",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "ff_ext",
  "gkr_iop",
  "halo2-axiom",
  "hex",
  "metrics",
- "mpcs 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "mpcs",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-benchmarks-prove",
@@ -6672,32 +6622,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
-dependencies = [
- "p3-air",
- "p3-baby-bear",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-goldilocks",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-mds",
- "p3-merkle-tree",
- "p3-monty-31",
- "p3-poseidon",
- "p3-poseidon2",
- "p3-poseidon2-air",
- "p3-symmetric",
- "p3-util",
-]
-
-[[package]]
-name = "p3"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -7438,20 +7363,10 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "serde",
-]
-
-[[package]]
-name = "poseidon"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "ff_ext",
+ "p3",
  "serde",
 ]
 
@@ -9630,16 +9545,16 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "cfg-if",
  "dashu",
  "elliptic-curve",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "generic-array 1.3.5",
  "itertools 0.13.0",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions",
  "num",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "p3-field",
@@ -9668,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#61f7d6a72958ad2e001da9f2ef5633f991970459"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2c8979e2e5c34118105cda8cb8f7e6fd14172f33"
 dependencies = [
  "cc",
  "which",
@@ -9677,12 +9592,12 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen_flow#61f7d6a72958ad2e001da9f2ef5633f991970459"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fwitnessgen#2c8979e2e5c34118105cda8cb8f7e6fd14172f33"
 dependencies = [
  "cc",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "p3",
  "sppark",
 ]
 
@@ -9787,59 +9702,28 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "either",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions",
+ "p3",
  "rayon",
  "serde",
- "sumcheck_macro 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "sumcheck_macro",
  "thiserror 1.0.69",
  "tracing",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
-]
-
-[[package]]
-name = "sumcheck"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "either",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "itertools 0.13.0",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "rayon",
- "serde",
- "sumcheck_macro 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "thiserror 1.0.69",
- "tracing",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "transcript",
 ]
 
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "itertools 0.13.0",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "proc-macro2",
- "quote",
- "rand 0.8.5",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "sumcheck_macro"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "itertools 0.13.0",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3",
  "proc-macro2",
  "quote",
  "rand 0.8.5",
@@ -10528,23 +10412,12 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.13.0",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "poseidon 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
-]
-
-[[package]]
-name = "transcript"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "itertools 0.13.0",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "poseidon 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "p3",
+ "poseidon",
 ]
 
 [[package]]
@@ -10915,47 +10788,24 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
  "bincode 1.3.3",
  "clap",
  "derive_more 1.0.0",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "ff_ext",
  "itertools 0.14.0",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "multilinear_extensions",
+ "p3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "sumcheck",
  "tracing",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
+ "transcript",
  "transpose",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
-]
-
-[[package]]
-name = "whir"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "bincode 1.3.3",
- "clap",
- "derive_more 1.0.0",
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "itertools 0.14.0",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rayon",
- "serde",
- "sumcheck 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "tracing",
- "transcript 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "transpose",
- "witness 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "witness",
 ]
 
 [[package]]
@@ -11316,24 +11166,11 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
 dependencies = [
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer)",
- "rand 0.8.5",
- "rayon",
- "tracing",
-]
-
-[[package]]
-name = "witness"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
-dependencies = [
- "ff_ext 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "multilinear_extensions 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
- "p3 0.1.0 (git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3)",
+ "ff_ext",
+ "multilinear_extensions",
+ "p3",
  "rand 0.8.5",
  "rayon",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ openvm-primitives = { path = "./crates/primitives" }
 openvm-reth-benchmark = { path = "./crates/host-bench", default-features = false }
 openvm-mpt = { path = "./crates/mpt" }
 # ceno
-ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
-ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
-ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
-ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "master" }
-ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
-gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
+ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
+ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
+ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
+ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen_fix" }
+ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
+gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
 ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.22" }
 mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.22" }
 
@@ -166,7 +166,7 @@ openvm-k256 = { git = "https://github.com/scroll-tech/openvm.git", package = "k2
 openvm-p256 = { git = "https://github.com/scroll-tech/openvm.git", package = "p256", branch = "feat/v1.4.1-scroll-ext" }
 
 [patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "main", default-features = false, features = ["bb31"] }
+ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/witnessgen", default-features = false, features = ["bb31"] }
 # ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-feature = false, features = ["bb31"] }
 
 [patch."https://github.com/axiom-crypto/openvm-kzg.git"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,14 +60,14 @@ openvm-primitives = { path = "./crates/primitives" }
 openvm-reth-benchmark = { path = "./crates/host-bench", default-features = false }
 openvm-mpt = { path = "./crates/mpt" }
 # ceno
-ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen" }
-ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.22" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.22" }
+ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
+ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
+ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
+ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen_flow" }
+ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
+gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
 
 # reth
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", default-features = false }
@@ -166,7 +166,7 @@ openvm-k256 = { git = "https://github.com/scroll-tech/openvm.git", package = "k2
 openvm-p256 = { git = "https://github.com/scroll-tech/openvm.git", package = "p256", branch = "feat/v1.4.1-scroll-ext" }
 
 [patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/witnessgen", default-features = false, features = ["bb31"] }
+ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/witnessgen_flow", default-features = false, features = ["bb31"] }
 # ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-feature = false, features = ["bb31"] }
 
 [patch."https://github.com/axiom-crypto/openvm-kzg.git"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,14 +60,14 @@ openvm-primitives = { path = "./crates/primitives" }
 openvm-reth-benchmark = { path = "./crates/host-bench", default-features = false }
 openvm-mpt = { path = "./crates/mpt" }
 # ceno
-ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
-ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
-ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
-ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen_flow" }
-ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
-gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_flow" }
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen" }
+ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.24" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.24" }
 
 # reth
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", default-features = false }
@@ -166,7 +166,7 @@ openvm-k256 = { git = "https://github.com/scroll-tech/openvm.git", package = "k2
 openvm-p256 = { git = "https://github.com/scroll-tech/openvm.git", package = "p256", branch = "feat/v1.4.1-scroll-ext" }
 
 [patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/witnessgen_flow", default-features = false, features = ["bb31"] }
+ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/witnessgen", default-features = false, features = ["bb31"] }
 # ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-feature = false, features = ["bb31"] }
 
 [patch."https://github.com/axiom-crypto/openvm-kzg.git"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ openvm-primitives = { path = "./crates/primitives" }
 openvm-reth-benchmark = { path = "./crates/host-bench", default-features = false }
 openvm-mpt = { path = "./crates/mpt" }
 # ceno
-ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen" }
-ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
-gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
+ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
+ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
+ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "master" }
+ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
+gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
 ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.24" }
 mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.24" }
 
@@ -166,7 +166,7 @@ openvm-k256 = { git = "https://github.com/scroll-tech/openvm.git", package = "k2
 openvm-p256 = { git = "https://github.com/scroll-tech/openvm.git", package = "p256", branch = "feat/v1.4.1-scroll-ext" }
 
 [patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/witnessgen", default-features = false, features = ["bb31"] }
+ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "main", default-features = false, features = ["bb31"] }
 # ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-feature = false, features = ["bb31"] }
 
 [patch."https://github.com/axiom-crypto/openvm-kzg.git"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ openvm-primitives = { path = "./crates/primitives" }
 openvm-reth-benchmark = { path = "./crates/host-bench", default-features = false }
 openvm-mpt = { path = "./crates/mpt" }
 # ceno
-ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
-ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
-ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
-ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen_fix" }
-ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
-gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen_fix" }
+ceno_emul = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ceno_host = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "feat/gpu-witnessgen" }
+ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
+gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "feat/gpu-witnessgen" }
 ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.22" }
 mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.22" }
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,18 +1,14 @@
 # syntax=docker/dockerfile:1.7
 
-FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.8.0-devel-ubuntu24.04
 
 ARG RUNNER_VERSION="2.320.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && apt upgrade -y && useradd -m docker
-RUN apt install -y --no-install-recommends software-properties-common \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update -y
 RUN apt install -y --no-install-recommends \
-    curl jq build-essential cmake libssl-dev libffi-dev python3.11 python3.11-venv python3.11-dev python3-pip \
-    libkrb5-3 zlib1g libicu70 m4
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+    curl jq build-essential cmake libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip \
+    libkrb5-3 zlib1g libicu74 m4
 
 RUN cd /home/docker && mkdir actions-runner && cd actions-runner \
     && curl -o actions-runner-linux-x64-2.320.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.320.0/actions-runner-linux-x64-2.320.0.tar.gz \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,9 +6,13 @@ ARG RUNNER_VERSION="2.320.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && apt upgrade -y && useradd -m docker
+RUN apt install -y --no-install-recommends software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update -y
 RUN apt install -y --no-install-recommends \
-    curl jq build-essential cmake libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip \
+    curl jq build-essential cmake libssl-dev libffi-dev python3.11 python3.11-venv python3.11-dev python3-pip \
     libkrb5-3 zlib1g libicu70 m4
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 RUN cd /home/docker && mkdir actions-runner && cd actions-runner \
     && curl -o actions-runner-linux-x64-2.320.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.320.0/actions-runner-linux-x64-2.320.0.tar.gz \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,14 +1,21 @@
 # syntax=docker/dockerfile:1.7
 
-FROM nvidia/cuda:12.8.0-devel-ubuntu24.04
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
 
 ARG RUNNER_VERSION="2.320.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -y && apt upgrade -y && useradd -m docker
-RUN apt install -y --no-install-recommends \
-    curl jq build-essential cmake libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip \
-    libkrb5-3 zlib1g libicu74 m4
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl jq build-essential cmake libssl-dev libffi-dev python3.11 python3.11-venv python3.11-dev python3-pip \
+        libkrb5-3 zlib1g libicu70 m4 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m docker
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 RUN cd /home/docker && mkdir actions-runner && cd actions-runner \
     && curl -o actions-runner-linux-x64-2.320.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.320.0/actions-runner-linux-x64-2.320.0.tar.gz \
@@ -19,9 +26,9 @@ RUN chown -R docker ~docker && cd /home/docker/actions-runner/bin/ \
     && chmod +x installdependencies.sh \
     && ./installdependencies.sh
 
-RUN apt install -y nvidia-utils-535
-RUN apt install -y openssh-client
-RUN apt install -y git
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nvidia-utils-535 openssh-client git \
+    && rm -rf /var/lib/apt/lists/*
 
 # Validate SSH access for private dependencies (requires --ssh sshkey=... at build time)
 RUN --mount=type=ssh,id=sshkey \
@@ -31,7 +38,8 @@ RUN --mount=type=ssh,id=sshkey \
     ssh-keyscan github.com >> /root/.ssh/known_hosts; \
     git ls-remote git@github.com:scroll-tech/ceno-reth-benchmark.git >/dev/null
 
-RUN apt install -y --no-install-recommends sudo && \
+RUN apt-get update && apt-get install -y --no-install-recommends sudo && \
+    rm -rf /var/lib/apt/lists/* && \
     echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 WORKDIR /home/docker/actions-runner

--- a/crates/host-bench/src/lib.rs
+++ b/crates/host-bench/src/lib.rs
@@ -348,7 +348,7 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
         ceno_sdk::CenoSDK::new_with_app_config(
             program,
             platform,
-            MultiProver::new(0, 1, (1 << 30) * 7 / 4 / 2, MAX_CYCLE_PER_SHARD),
+            MultiProver::new(0, 1, (1 << 30) * 8 / 4 / 2, MAX_CYCLE_PER_SHARD),
         );
 
     ceno_sdk.init_base_prover(max_num_variables, security_level);

--- a/crates/host-bench/src/lib.rs
+++ b/crates/host-bench/src/lib.rs
@@ -348,7 +348,7 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
         ceno_sdk::CenoSDK::new_with_app_config(
             program,
             platform,
-            MultiProver::new(0, 1, (1 << 30) * 8 / 4 / 2, MAX_CYCLE_PER_SHARD),
+            MultiProver::new(0, 1, (1 << 30) * 7 / 4 / 2, MAX_CYCLE_PER_SHARD),
         );
 
     ceno_sdk.init_base_prover(max_num_variables, security_level);

--- a/crates/host-bench/src/lib.rs
+++ b/crates/host-bench/src/lib.rs
@@ -219,9 +219,7 @@ static WORKSPACE_ROOT: LazyLock<PathBuf> = LazyLock::new(discover_workspace_root
 fn setup() -> (Vec<u8>, Program, Platform) {
     let stack_size = 128 * 1024 * 1024;
     let heap_size = 128 * 1024 * 1024;
-    println!(
-        "stack_size: {stack_size:#x}, heap_size: {heap_size:#x}"
-    );
+    println!("stack_size: {stack_size:#x}, heap_size: {heap_size:#x}");
 
     let elf_path = WORKSPACE_ROOT
         .join("bin")
@@ -232,8 +230,7 @@ fn setup() -> (Vec<u8>, Program, Platform) {
         .join("ceno-client-eth");
     let elf = std::fs::read(elf_path).unwrap();
     let program = Program::load_elf(&elf, u32::MAX).unwrap();
-    let platform =
-        setup_platform(Preset::Ceno, &program, stack_size, heap_size);
+    let platform = setup_platform(Preset::Ceno, &program, stack_size, heap_size);
     (elf, program, platform)
 }
 
@@ -421,10 +418,13 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
                     BenchMode::ProveApp => {
                         let mut hints = CenoStdin::default();
 
-                        let pub_io_digest = info_span!("app.hints").in_scope(|| -> eyre::Result<_> {
-                            hints.write(&client_input)?;
-                            Ok(unsafe { core::mem::transmute::<[u8; 32], [u32; 8]>(block_hash.0) })
-                        })?;
+                        let pub_io_digest =
+                            info_span!("app.hints").in_scope(|| -> eyre::Result<_> {
+                                hints.write(&client_input)?;
+                                Ok(unsafe {
+                                    core::mem::transmute::<[u8; 32], [u32; 8]>(block_hash.0)
+                                })
+                            })?;
 
                         let proofs = info_span!("app.prove").in_scope(|| {
                             ceno_sdk.generate_base_proof(
@@ -453,10 +453,13 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
                     BenchMode::ProveStark => {
                         let mut hints = CenoStdin::default();
 
-                        let pub_io_digest = info_span!("app.hints").in_scope(|| -> eyre::Result<_> {
-                            hints.write(&client_input)?;
-                            Ok(unsafe { core::mem::transmute::<[u8; 32], [u32; 8]>(block_hash.0) })
-                        })?;
+                        let pub_io_digest =
+                            info_span!("app.hints").in_scope(|| -> eyre::Result<_> {
+                                hints.write(&client_input)?;
+                                Ok(unsafe {
+                                    core::mem::transmute::<[u8; 32], [u32; 8]>(block_hash.0)
+                                })
+                            })?;
 
                         let proofs = info_span!("app.prove").in_scope(|| {
                             ceno_sdk.generate_base_proof(

--- a/scripts/patch_ceno_pr_deps.py
+++ b/scripts/patch_ceno_pr_deps.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import argparse
 import re
 import sys
-import tomllib
 from pathlib import Path
+import tomllib
 
 CENO_GIT = "https://github.com/scroll-tech/ceno"
 CENO_WORKSPACE_CRATES: dict[str, dict[str, object]] = {

--- a/scripts/patch_ceno_pr_deps.py
+++ b/scripts/patch_ceno_pr_deps.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+CENO_GIT = "https://github.com/scroll-tech/ceno"
+CENO_WORKSPACE_CRATES: dict[str, dict[str, object]] = {
+    "ceno_emul": {},
+    "ceno_host": {},
+    "ceno_zkvm": {},
+    "ceno_cli": {"package": "cargo-ceno"},
+    "ceno_recursion": {},
+    "gkr_iop": {},
+}
+GUEST_CENO_CRATES: dict[str, dict[str, object]] = {
+    "ceno_rt": {"default-features": False},
+    "ceno_crypto": {"default-features": False},
+}
+GKR_CRATES = ("ff_ext", "mpcs")
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def format_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return f'"{value}"'
+    if isinstance(value, list):
+        return "[" + ", ".join(format_value(v) for v in value) + "]"
+    raise TypeError(f"Unsupported TOML value: {value!r}")
+
+
+def format_inline_table(items: list[tuple[str, object]]) -> str:
+    rendered = ", ".join(f"{key} = {format_value(value)}" for key, value in items)
+    return "{ " + rendered + " }"
+
+
+def replace_inline_dep(text: str, dep_name: str, inline_value: str, path: Path) -> str:
+    pattern = re.compile(rf"^(?P<prefix>{re.escape(dep_name)}\s*=\s*)\{{.*\}}\s*$", re.MULTILINE)
+    new_text, count = pattern.subn(rf"\g<prefix>{inline_value}", text, count=1)
+    if count != 1:
+        raise RuntimeError(f"Failed to replace dependency '{dep_name}' in {path}")
+    return new_text
+
+
+def patch_workspace_cargo(benchmark_cargo: Path, ceno_cargo: Path, ceno_ref: str) -> None:
+    benchmark_text = benchmark_cargo.read_text()
+    ceno_toml = load_toml(ceno_cargo)
+    ceno_workspace_deps = ceno_toml["workspace"]["dependencies"]
+
+    for dep_name, extra in CENO_WORKSPACE_CRATES.items():
+        items: list[tuple[str, object]] = [("git", CENO_GIT)]
+        if "package" in extra:
+            items.append(("package", extra["package"]))
+        items.append(("rev", ceno_ref))
+        benchmark_text = replace_inline_dep(
+            benchmark_text,
+            dep_name,
+            format_inline_table(items),
+            benchmark_cargo,
+        )
+
+    for dep_name in GKR_CRATES:
+        spec = ceno_workspace_deps[dep_name]
+        items: list[tuple[str, object]] = [("git", spec["git"])]
+        if "package" in spec:
+            items.append(("package", spec["package"]))
+        for key in ("branch", "tag", "rev"):
+            if key in spec:
+                items.append((key, spec[key]))
+                break
+        benchmark_text = replace_inline_dep(
+            benchmark_text,
+            dep_name,
+            format_inline_table(items),
+            benchmark_cargo,
+        )
+
+    benchmark_cargo.write_text(benchmark_text)
+
+
+def patch_guest_cargo(guest_cargo: Path, ceno_ref: str) -> None:
+    guest_text = guest_cargo.read_text()
+    for dep_name, extra in GUEST_CENO_CRATES.items():
+        items: list[tuple[str, object]] = [("git", CENO_GIT), ("rev", ceno_ref)]
+        for key, value in extra.items():
+            items.append((key, value))
+        guest_text = replace_inline_dep(
+            guest_text,
+            dep_name,
+            format_inline_table(items),
+            guest_cargo,
+        )
+    guest_cargo.write_text(guest_text)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Patch ceno-reth-benchmark to use a Ceno PR ref")
+    parser.add_argument("--benchmark-root", required=True)
+    parser.add_argument("--ceno-root", required=True)
+    parser.add_argument("--ceno-ref", required=True)
+    args = parser.parse_args()
+
+    benchmark_root = Path(args.benchmark_root).resolve()
+    ceno_root = Path(args.ceno_root).resolve()
+
+    benchmark_cargo = benchmark_root / "Cargo.toml"
+    guest_cargo = benchmark_root / "bin" / "ceno-client-eth" / "Cargo.toml"
+    ceno_cargo = ceno_root / "Cargo.toml"
+
+    if not benchmark_cargo.exists() or not guest_cargo.exists() or not ceno_cargo.exists():
+        raise SystemExit("Required Cargo.toml file is missing")
+
+    patch_workspace_cargo(benchmark_cargo, ceno_cargo, args.ceno_ref)
+    patch_guest_cargo(guest_cargo, args.ceno_ref)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/resolve_ceno_source.py
+++ b/scripts/resolve_ceno_source.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tomllib
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve the ceno source used by benchmark workflows"
+    )
+    parser.add_argument("--benchmark-root", required=True)
+    parser.add_argument("--requested-ref", default="")
+    args = parser.parse_args()
+
+    requested_ref = args.requested_ref.strip()
+    if requested_ref:
+        print("CENO_USE_PINNED=false")
+        print(f"CENO_REQUESTED_VERSION={requested_ref}")
+        return 0
+
+    cargo_toml = Path(args.benchmark_root).resolve() / "Cargo.toml"
+    data = tomllib.loads(cargo_toml.read_text())
+    spec = data["workspace"]["dependencies"]["ceno_cli"]
+
+    print("CENO_USE_PINNED=true")
+    print(f"CENO_PINNED_GIT={spec['git']}")
+    print(f"CENO_PINNED_PACKAGE={spec.get('package', 'cargo-ceno')}")
+
+    for key in ("branch", "tag", "rev"):
+        if key in spec:
+            print(f"CENO_PINNED_REF_KIND={key}")
+            print(f"CENO_PINNED_REF_VALUE={spec[key]}")
+            return 0
+
+    raise SystemExit("ceno_cli dependency is missing branch, tag, or rev")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_ceno_source.py
+++ b/scripts/resolve_ceno_source.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import argparse
-import tomllib
 from pathlib import Path
+import tomllib
 
 
 def main() -> int:


### PR DESCRIPTION
Update the benchmark workflow in `ceno-reth-benchmark` to support cross-repo dispatches from `scroll-tech/ceno`.

- accept `ceno_version`, source repo, and source PR inputs
- use the dispatched ceno ref when provided, otherwise keep the pinned Cargo.toml version
- post benchmark results back to the source PR as a comment
- update the self-hosted runner image baseline for Python 3.11+ / Ubuntu 24.04 workflow support
