### PR TITLE
Update Ceno deps and Jagged benchmark path

### DIFF
--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -22,7 +22,7 @@ on:
         description: "Block number to generate input for"
         required: true
         type: string
-        default: "23100006"
+        default: "23817600"
       rerun_keygen:
         description: "Rerun keygen"
         required: false
@@ -85,6 +85,25 @@ on:
         options:
           - "0"
           - "1"
+      gpu_cache_level:
+        description: "Value for CENO_GPU_CACHE_LEVEL: 0/none disables GPU cache, 1/trace caches trace only, 2/full caches trace and encoded codeword"
+        required: false
+        type: choice
+        default: "1"
+        options:
+          - "0"
+          - "1"
+          - "2"
+      max_cell_per_shard:
+        description: "Value for CENO_MAX_CELL_PER_SHARD; 1207959552 = (1 << 30) * 9 / 4 / 2"
+        required: false
+        type: string
+        default: "1207959552"
+      gpu_jagged_reshape_log_height:
+        description: "Value for CENO_GPU_JAGGED_RESHAPE_LOG_HEIGHT; 25 probably OOMs on RTX 4090"
+        required: false
+        type: string
+        default: "24"
 
 jobs:
   check-gpu-mem-estimation:
@@ -188,8 +207,10 @@ jobs:
           CENO_CONCURRENT_CHIP_PROVING=${{ inputs.concurrent_chip_proving }} \
           CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB=${{ inputs.gpu_large_task_booking_margin_mb }} \
           CENO_GPU_ENABLE_WITGEN=${{ inputs.gpu_enable_witgen }} \
+          CENO_MAX_CELL_PER_SHARD=${{ inputs.max_cell_per_shard }} \
           RUST_MIN_STACK=16777216 \
-          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
+          CENO_GPU_JAGGED_RESHAPE_LOG_HEIGHT=${{ inputs.gpu_jagged_reshape_log_height }} \
+          CENO_GPU_CACHE_LEVEL=${{ inputs.gpu_cache_level }} RUSTFLAGS="-C target-feature=+avx2" \
           RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
           cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
             --release --bin ceno-reth-benchmark-bin -- \
@@ -201,6 +222,12 @@ jobs:
           benchmark_status=$?
           set -e
           grep -v '\[ceno-gpu\]' "$LOG_FILE" # filter out ceno-gpu logs
+          echo "Generated proof output sizes:"
+          if find output -type f -print -quit | grep -q .; then
+            find output -type f -printf "%p %s\n" | sort | awk '{size=$NF; path=$0; sub(/[[:space:]][0-9]+$/, "", path); printf "%s %d bytes %.2f MiB\n", path, size, size / 1048576}'
+          else
+            echo "No proof output files found in output/"
+          fi
           if [ $benchmark_status -ne 0 ]; then
             echo "GPU memory tracking benchmark failed with status $benchmark_status"
             if [ "${{ inputs.ignore_failed }}" != "true" ]; then
@@ -313,7 +340,9 @@ jobs:
           CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB=${{ inputs.gpu_large_task_booking_margin_mb }} \
           RUST_MIN_STACK=16777216 \
           CENO_GPU_ENABLE_WITGEN=${{ inputs.gpu_enable_witgen }} \
-          CENO_GPU_CACHE_LEVEL=0 RUSTFLAGS="-C target-feature=+avx2" \
+          CENO_MAX_CELL_PER_SHARD=${{ inputs.max_cell_per_shard }} \
+          CENO_GPU_JAGGED_RESHAPE_LOG_HEIGHT=${{ inputs.gpu_jagged_reshape_log_height }} \
+          CENO_GPU_CACHE_LEVEL=${{ inputs.gpu_cache_level }} RUSTFLAGS="-C target-feature=+avx2" \
           RUST_LOG=info,openvm_stark_*=warn,openvm_cuda_common=warn \
           cargo run --features "jemalloc,gpu" --config net.git-fetch-with-cli=true \
             --release --bin ceno-reth-benchmark-bin -- \
@@ -325,6 +354,12 @@ jobs:
           benchmark_status=$?
           set -e
           grep -v '\[ceno-gpu\]' "$LOG_FILE" # filter out ceno-gpu logs
+          echo "Generated proof output sizes:"
+          if find output -type f -print -quit | grep -q .; then
+            find output -type f -printf "%p %s\n" | sort | awk '{size=$NF; path=$0; sub(/[[:space:]][0-9]+$/, "", path); printf "%s %d bytes %.2f MiB\n", path, size, size / 1048576}'
+          else
+            echo "No proof output files found in output/"
+          fi
           if [ $benchmark_status -ne 0 ]; then
             echo "Benchmark run failed with status $benchmark_status"
             if [ "${{ inputs.ignore_failed }}" != "true" ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#541ad2be78ceb288c16f4c4feee5f5ef5ae9b589"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#3f5fe2dd9398e6593d36291b359e4361d756f5ce"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "once_cell",
  "p3",
@@ -3647,7 +3647,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -4967,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -4978,7 +4978,6 @@ dependencies = [
  "p3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rayon",
  "serde",
  "sumcheck",
  "tracing",
@@ -4991,7 +4990,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "either",
  "ff_ext",
@@ -6625,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -7366,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "ff_ext",
  "p3",
@@ -9548,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -9586,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#541ad2be78ceb288c16f4c4feee5f5ef5ae9b589"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#3f5fe2dd9398e6593d36291b359e4361d756f5ce"
 dependencies = [
  "cc",
  "which",
@@ -9595,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#541ad2be78ceb288c16f4c4feee5f5ef5ae9b589"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#3f5fe2dd9398e6593d36291b359e4361d756f5ce"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9705,7 +9704,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "either",
  "ff_ext",
@@ -9723,7 +9722,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -10415,7 +10414,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -10791,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -11169,7 +11168,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.29#2222cf29bc7d16ad245350200da7b4dbaf902c5d"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cargo-ceno"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "ceno-examples"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "glob",
 ]
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "ceno_emul"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "anyhow",
  "ceno_rt",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ceno_host"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "anyhow",
  "ceno_emul",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ceno_recursion"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "bincode 1.3.3",
  "ceno-examples",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1963,7 +1963,7 @@ source = "git+https://github.com/scroll-tech/ceno-patch.git?branch=main#6e90bc85
 [[package]]
 name = "ceno_zkvm"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2431,12 +2431,13 @@ dependencies = [
 [[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#911741992d4a95c074b9d31b8bc6257dae8fa1d8"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#541ad2be78ceb288c16f4c4feee5f5ef5ae9b589"
 dependencies = [
  "anyhow",
  "cuda-runtime-sys",
  "cudarc",
  "downcast-rs",
+ "either",
  "ff_ext",
  "itertools 0.13.0",
  "mpcs",
@@ -2662,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "derive"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3301,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "once_cell",
  "p3",
@@ -3646,7 +3647,7 @@ dependencies = [
 [[package]]
 name = "gkr_iop"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#9936d96ed51f9e2d11a0aa184100c517fa960095"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#298ea12198463b3d820b1c68fc3f180f42ec0825"
 dependencies = [
  "bincode 1.3.3",
  "cuda_hal",
@@ -4966,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -4990,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "either",
  "ff_ext",
@@ -6624,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -7365,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "ff_ext",
  "p3",
@@ -9547,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -9585,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#911741992d4a95c074b9d31b8bc6257dae8fa1d8"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#541ad2be78ceb288c16f4c4feee5f5ef5ae9b589"
 dependencies = [
  "cc",
  "which",
@@ -9594,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "sppark_plug"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#911741992d4a95c074b9d31b8bc6257dae8fa1d8"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=main#541ad2be78ceb288c16f4c4feee5f5ef5ae9b589"
 dependencies = [
  "cc",
  "ff_ext",
@@ -9704,7 +9705,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "either",
  "ff_ext",
@@ -9722,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -10414,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -10790,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -11168,7 +11169,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.24#a3538e3529a7eb87e8867f4a87b760d7ad9991f7"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
 ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "master" }
 ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
 gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.24" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.24" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.25" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.25" }
 
 # reth
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ ceno_zkvm = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
 ceno_cli = { git = "https://github.com/scroll-tech/ceno", package = "cargo-ceno", branch = "master" }
 ceno_recursion = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
 gkr_iop = { git = "https://github.com/scroll-tech/ceno", branch = "master" }
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.25" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.25" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.29" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", tag = "v1.0.0-alpha.29" }
 
 # reth
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", default-features = false }

--- a/bin/ceno-client-eth/Cargo.lock
+++ b/bin/ceno-client-eth/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "ceno_crypto"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#4b6c3daa74bf7a6da96959e9a9b8e79d482bd6f7"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "ceno_keccak",
  "ceno_sha2",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "ceno_keccak"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#4b6c3daa74bf7a6da96959e9a9b8e79d482bd6f7"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "ceno_syscall",
  "tiny-keccak",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#4b6c3daa74bf7a6da96959e9a9b8e79d482bd6f7"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "ceno_serde",
  "ceno_syscall",
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "ceno_serde"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#4b6c3daa74bf7a6da96959e9a9b8e79d482bd6f7"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "ceno_sha2"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno?branch=master#4b6c3daa74bf7a6da96959e9a9b8e79d482bd6f7"
+source = "git+https://github.com/scroll-tech/ceno?branch=master#22a1897322151d788dfec6a236b723c7acb2765a"
 dependencies = [
  "ceno_syscall",
  "digest 0.10.7",

--- a/ci/trace_profiler.py
+++ b/ci/trace_profiler.py
@@ -174,7 +174,13 @@ def analyze_trace_log(file_path: str):
 
         # Track when we enter a module block (for GPU operations breakdown)
         # We update module context whenever we see these operations, even if nested
-        if operation in ['commit_traces', 'prove_tower_relation_gpu', 'prove_main_constraints', 'pcs_opening']:
+        if operation in [
+            'commit_traces',
+            'prove_tower_relation_gpu',
+            'prove_main_constraints',
+            'prove_batched_main_constraints',
+            'pcs_opening',
+        ]:
             current_module = operation
             module_indent_level = indent
         # Exit the module block when we see a sibling or parent operation (but not children)
@@ -200,6 +206,7 @@ def analyze_trace_log(file_path: str):
             'transport_structural_witness',
             'build_tower_witness_gpu',
             'prove_tower_relation_gpu',
+            'prove_batched_main_constraints',
             'prove_main_constraints',
             'pcs_opening',
         ]:
@@ -260,6 +267,7 @@ def generate_summary_markdown(app_prove_inner_time: float,
         'transport_structural_witness',
         'build_tower_witness_gpu',
         'prove_tower_relation_gpu',
+        'prove_batched_main_constraints',
         'prove_main_constraints',
         'pcs_opening',
     ]
@@ -396,9 +404,15 @@ def generate_breakdown_module_markdown(app_prove_inner_time: float,
     output.append(f"**Total app_prove.inner time: {app_prove_inner_time:.3f}s**\n")
 
     # Main modules to analyze
-    modules = ['commit_traces', 'prove_tower_relation_gpu', 'prove_main_constraints', 'pcs_opening']
+    modules = [
+        'commit_traces',
+        'prove_tower_relation_gpu',
+        'prove_batched_main_constraints',
+        'prove_main_constraints',
+        'pcs_opening',
+    ]
 
-    # Table 1: Summary of 4 modules
+    # Table 1: Summary of main modules
     output.append("## Table 1: Modules Summary\n")
     output.append("| Module | Time (s) | % of app_prove.inner |")
     output.append("|--------|----------|---------------------|")
@@ -432,13 +446,16 @@ def generate_breakdown_module_markdown(app_prove_inner_time: float,
         'prove_main_constraints': [
             'prove_generic_sumcheck_gpu',
         ],
+        'prove_batched_main_constraints': [
+            'prove_generic_sumcheck_gpu',
+        ],
         'pcs_opening': [
             'batch_commit_phase',
             'batch_query_phase',
         ],
     }
 
-    # Table 2-5: Breakdown for each module
+    # Detailed breakdown for each module.
     table_num = 2
     for module in modules:
         module_time = total_by_operation.get(module, 0.0)

--- a/crates/host-bench/src/lib.rs
+++ b/crates/host-bench/src/lib.rs
@@ -474,10 +474,31 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
         BabyBearPoseidon2Config,
         NativeConfig,
     > = ceno_sdk::CenoSDK::new_with_app_config(
-        program,
-        platform,
+        program.clone(),
+        platform.clone(),
         MultiProver::new(0, 1, max_cell_per_shard, MAX_CYCLE_PER_SHARD),
     );
+
+    let new_basefold_sdk = || -> eyre::Result<
+        ceno_sdk::CenoSDK<
+            ff_ext::BabyBearExt4,
+            mpcs::Basefold<ff_ext::BabyBearExt4, mpcs::BasefoldRSParams>,
+            BabyBearPoseidon2Config,
+            NativeConfig,
+        >,
+    > {
+        let mut sdk = ceno_sdk::CenoSDK::new_with_app_config(
+            program.clone(),
+            platform.clone(),
+            MultiProver::new(0, 1, (1 << 30) * 8 / 4 / 2, MAX_CYCLE_PER_SHARD),
+        );
+        sdk.init_base_prover(max_num_variables, security_level);
+        if let Some(agg_pk_path) = args.agg_pk_path.as_ref() {
+            let agg_pk = read_object_from_file(agg_pk_path)?;
+            sdk.set_agg_pk(agg_pk);
+        }
+        Ok(sdk)
+    };
 
     ceno_sdk.init_base_prover(max_num_variables, security_level);
     info!("setup ceno sdk done in {:?}", start.elapsed());
@@ -590,10 +611,67 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
                         });
                     }
                     BenchMode::ProveStark => {
-                        eyre::bail!("Ceno Jagged benchmark currently supports prove-app only")
+                        let mut basefold_sdk = new_basefold_sdk()?;
+                        let mut hints = CenoStdin::default();
+
+                        let pub_io_digest =
+                            info_span!("app.hints").in_scope(|| -> eyre::Result<_> {
+                                write_ceno_client_input(&mut hints, &client_input)?;
+                                Ok(unsafe {
+                                    core::mem::transmute::<[u8; 32], [u32; 8]>(block_hash.0)
+                                })
+                            })?;
+
+                        let proofs = info_span!("app.prove").in_scope(|| {
+                            basefold_sdk.generate_base_proof(
+                                hints,
+                                pub_io_digest,
+                                max_steps,
+                                args.shard_id.map(|v| v as usize),
+                            )
+                        });
+
+                        if let Some(output_dir) = args.output_dir.as_ref() {
+                            let mut path = output_dir.clone();
+                            path.push("app_proof.bitcode");
+                            fs::write(path, bitcode::serialize(&proofs)?)?;
+                        };
+
+                        let vm_stark_proof = info_span!("recursion.compress_to_root_proof")
+                            .in_scope(|| basefold_sdk.compress_to_root_proof(proofs));
+
+                        info_span!("recursion.verify").in_scope(|| {
+                            verify_e2e_stark_proof(
+                                &basefold_sdk.get_agg_verifier(),
+                                &vm_stark_proof,
+                                &Bn254Fr::ZERO,
+                                &Bn254Fr::ZERO,
+                            )
+                            .expect("root proof verification failed");
+                        });
+
+                        if let Some(output_dir) = args.output_dir.as_ref() {
+                            let versioned_proof = VersionedVmStarkProof::new(vm_stark_proof)?;
+                            write_versioned_proof(output_dir, args.block_number, versioned_proof)?;
+                        }
                     }
                     BenchMode::ProveStarkOnly => {
-                        eyre::bail!("Ceno Jagged benchmark currently supports prove-app only")
+                        let mut basefold_sdk = new_basefold_sdk()?;
+                        let Some(app_proofs_path) = args.app_proofs.as_ref() else {
+                            panic!("empty app_proofs_path")
+                        };
+                        let proofs = read_object_from_file(app_proofs_path)?;
+                        let vm_stark_proof = info_span!("recursion.compress_to_root_proof")
+                            .in_scope(|| basefold_sdk.compress_to_root_proof(proofs));
+                        info_span!("recursion.verify").in_scope(|| {
+                            verify_e2e_stark_proof(
+                                &basefold_sdk.get_agg_verifier(),
+                                &vm_stark_proof,
+                                &Bn254Fr::ZERO,
+                                &Bn254Fr::ZERO,
+                            )
+                            .expect("root proof verification failed");
+                        });
                     }
                     #[cfg(feature = "evm-verify")]
                     BenchMode::ProveEvm => {
@@ -612,7 +690,15 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
                         println!("block_hash (prove_evm): {}", ToHexExt::encode_hex(block_hash));
                     }
                     BenchMode::GenerateFixtures => {
-                        eyre::bail!("Ceno Jagged benchmark currently supports prove-app only")
+                        let mut basefold_sdk = new_basefold_sdk()?;
+                        let _app_pk = basefold_sdk.get_app_pk();
+                        let agg_pk = basefold_sdk.init_agg_pk();
+
+                        let fixture_path = args.fixtures_path.unwrap();
+
+                        let mut agg_pk_path = fixture_path.clone();
+                        agg_pk_path.push("agg_pk.bitcode");
+                        fs::write(agg_pk_path, bitcode::serialize(&agg_pk)?)?;
                     }
                     _ => {
                         // This case is handled earlier and should not reach here

--- a/crates/host-bench/src/lib.rs
+++ b/crates/host-bench/src/lib.rs
@@ -463,12 +463,21 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
     let max_steps = usize::MAX;
 
     let start = std::time::Instant::now();
-    let mut ceno_sdk: ceno_sdk::CenoSDK<_, _, BabyBearPoseidon2Config, NativeConfig> =
-        ceno_sdk::CenoSDK::new_with_app_config(
-            program,
-            platform,
-            MultiProver::new(0, 1, (1 << 30) * 8 / 4 / 2, MAX_CYCLE_PER_SHARD),
-        );
+    let max_cell_per_shard = std::env::var("CENO_MAX_CELL_PER_SHARD")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or((1 << 30) * 8 / 4 / 2);
+
+    let mut ceno_sdk: ceno_sdk::CenoSDK<
+        ff_ext::BabyBearExt4,
+        mpcs::Jagged<mpcs::Basefold<ff_ext::BabyBearExt4, mpcs::BasefoldRSParams>>,
+        BabyBearPoseidon2Config,
+        NativeConfig,
+    > = ceno_sdk::CenoSDK::new_with_app_config(
+        program,
+        platform,
+        MultiProver::new(0, 1, max_cell_per_shard, MAX_CYCLE_PER_SHARD),
+    );
 
     ceno_sdk.init_base_prover(max_num_variables, security_level);
     info!("setup ceno sdk done in {:?}", start.elapsed());
@@ -581,77 +590,10 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
                         });
                     }
                     BenchMode::ProveStark => {
-                        let mut hints = CenoStdin::default();
-
-                        let pub_io_digest =
-                            info_span!("app.hints").in_scope(|| -> eyre::Result<_> {
-                                write_ceno_client_input(&mut hints, &client_input)?;
-                                Ok(unsafe {
-                                    core::mem::transmute::<[u8; 32], [u32; 8]>(block_hash.0)
-                                })
-                            })?;
-
-                        let proofs = info_span!("app.prove").in_scope(|| {
-                            ceno_sdk.generate_base_proof(
-                                hints,
-                                pub_io_digest,
-                                max_steps,
-                                args.shard_id.map(|v| v as usize),
-                            )
-                        });
-
-                        if let Some(output_dir) = args.output_dir.as_ref() {
-                            let mut path = output_dir.clone();
-                            path.push("app_proof.bitcode");
-                            fs::write(path, bitcode::serialize(&proofs)?)?;
-                        };
-
-                        let vm_stark_proof = info_span!("recursion.compress_to_root_proof")
-                            .in_scope(|| ceno_sdk.compress_to_root_proof(proofs));
-
-                        // TODO check verify result
-                        info_span!("recursion.verify").in_scope(|| {
-                            verify_e2e_stark_proof(
-                                &ceno_sdk.get_agg_verifier(),
-                                &vm_stark_proof,
-                                &Bn254Fr::ZERO,
-                                &Bn254Fr::ZERO,
-                            )
-                            .expect("root proof verification failed");
-                        });
-
-                        // let mut prover = sdk.prover(elf)?.with_program_name(program_name);
-                        // let proof = prover.prove(stdin)?;
-                        // let block_hash = proof
-                        //     .user_public_values
-                        //     .iter()
-                        //     .map(|pv| pv.as_canonical_u32() as u8)
-                        //     .collect::<Vec<u8>>();
-                        // println!("block_hash (prove_stark): {}",
-                        // ToHexExt::encode_hex(&block_hash));
-                        //
-                        if let Some(output_dir) = args.output_dir.as_ref() {
-                            let versioned_proof = VersionedVmStarkProof::new(vm_stark_proof)?;
-                            write_versioned_proof(output_dir, args.block_number, versioned_proof)?;
-                        }
+                        eyre::bail!("Ceno Jagged benchmark currently supports prove-app only")
                     }
                     BenchMode::ProveStarkOnly => {
-                        let Some(app_proofs_path) = args.app_proofs.as_ref() else {
-                            panic!("empty app_proofs_path")
-                        };
-                        let proofs = read_object_from_file(app_proofs_path)?;
-                        let vm_stark_proof = info_span!("recursion.compress_to_root_proof")
-                            .in_scope(|| ceno_sdk.compress_to_root_proof(proofs));
-                        // TODO check verify result
-                        info_span!("recursion.verify").in_scope(|| {
-                            verify_e2e_stark_proof(
-                                &ceno_sdk.get_agg_verifier(),
-                                &vm_stark_proof,
-                                &Bn254Fr::ZERO,
-                                &Bn254Fr::ZERO,
-                            )
-                            .expect("root proof verification failed");
-                        });
+                        eyre::bail!("Ceno Jagged benchmark currently supports prove-app only")
                     }
                     #[cfg(feature = "evm-verify")]
                     BenchMode::ProveEvm => {
@@ -670,20 +612,7 @@ pub async fn run_ceno_reth_benchmark(args: HostArgs) -> eyre::Result<()> {
                         println!("block_hash (prove_evm): {}", ToHexExt::encode_hex(block_hash));
                     }
                     BenchMode::GenerateFixtures => {
-                        // generate pk,vk if needed
-                        let _app_pk = ceno_sdk.get_app_pk();
-                        let agg_pk = ceno_sdk.init_agg_pk();
-
-                        let fixture_path = args.fixtures_path.unwrap();
-
-                        // TODO serialize ceno app pk
-                        // let mut app_pk_path = fixture_path.clone();
-                        // app_pk_path.push("app_pk.bitcode");
-                        // fs::write(app_pk_path, bitcode::serialize(&app_pk)?)?;
-
-                        let mut agg_pk_path = fixture_path.clone();
-                        agg_pk_path.push("agg_pk.bitcode");
-                        fs::write(agg_pk_path, bitcode::serialize(&agg_pk)?)?;
+                        eyre::bail!("Ceno Jagged benchmark currently supports prove-app only")
                     }
                     _ => {
                         // This case is handled earlier and should not reach here


### PR DESCRIPTION
## Summary

Update Ceno benchmark deps and wire the benchmark path for Jagged PCS while keeping recursion/fixture paths on Basefold.

## Highlights

- Bump `ceno` master pins to `22a1897` for host and guest crates.
- Bump `ceno-gpu` main pin to `3f5fe2d`.
- Bump `gkr-backend` from `v1.0.0-alpha.24` to `v1.0.0-alpha.29`.
- Use `Jagged<Basefold>` for `prove-app`; keep `prove-stark`, `prove-stark-only`, and fixture generation on fixed Basefold max-cell settings.
- Add benchmark dispatch knobs for GPU cache level, max cells per shard, and jagged reshape height; default block is `23817600`.
- Extend trace profiling for `prove_batched_main_constraints`.

## Notes

- `CENO_MAX_CELL_PER_SHARD` is configurable only for the Jagged path.
- Basefold path keeps the original `(1 << 30) * 8 / 4 / 2` shard size.
